### PR TITLE
[tensorflow-lite] fix arm64-osx build failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -235,22 +235,7 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x64-osx
-          - task: CopyFiles@2
-            inputs:
-              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/tensorflow-lite"
-              Contents: |
-                ?(*.log|*.txt)
-                *.cmake
-              TargetFolder: "$(Build.ArtifactStagingDirectory)"
-              OverWrite: true
-            condition: always()
-          - task: PublishBuildArtifacts@1
-            displayName: "Publish Staged Logs"
-            inputs:
-              PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-              ArtifactName: "$(Agent.JobName)"
-            condition: always()
-            
+
       - job: "port_ios"
         displayName: "iOS(11)"
         pool:
@@ -268,7 +253,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "arm64-osx"
             inputs:
-              vcpkgArguments: "cpuinfo openssl3 zlib-ng metal-cpp fft2d farmhash"
+              vcpkgArguments: "cpuinfo openssl3 zlib-ng metal-cpp fft2d farmhash tensorflow-lite[gpu]"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-osx

--- a/ports/tensorflow-lite/fix-gpu-build.patch
+++ b/ports/tensorflow-lite/fix-gpu-build.patch
@@ -123,13 +123,13 @@ index 8bb43fd9..b520e4ea 100644
 +      COMPILE_OPTIONS "-fobjc-arc"
 +    )
 +    list(APPEND TFLITE_DELEGATES_COREML_SRCS
-+      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate.mm
-+      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate_kernel.mm
-+      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_executor.mm
-+      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate.h
-+      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate_kernel.h
-+      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_executor.h
++      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate.h        ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate.mm
++      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate_kernel.h ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_delegate_kernel.mm
++      ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_executor.h        ${TFLITE_SOURCE_DIR}/delegates/coreml/coreml_executor.mm
 +      ${TFLITE_SOURCE_DIR}/tools/delegates/coreml_delegate_provider.cc
++      # ...
++      ${TFLITE_SOURCE_DIR}/tools/tool_params.cc
++      ${TFLITE_SOURCE_DIR}/tools/command_line_flags.cc 
 +    )
 +    set_source_files_properties(${TFLITE_OBJC_SRCS} ${TFLITE_DELEGATES_GPU_METAL_SRCS} ${TFLITE_DELEGATES_COREML_SRCS}
 +    PROPERTIES

--- a/ports/tensorflow-lite/vcpkg.json
+++ b/ports/tensorflow-lite/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tensorflow-lite",
   "version-semver": "2.6.1",
+  "port-version": 1,
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://www.tensorflow.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -54,7 +54,7 @@
     },
     "tensorflow-lite": {
       "baseline": "2.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "tensorpipe": {
       "baseline": "2021-11-13",

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f4a9b43671b9bf9d0d3b13d5354c799013ddc375",
+      "version-semver": "2.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a2ed408d7ea8d9bb5ddce793c5c6f3799e90de05",
       "version-semver": "2.6.1",
       "port-version": 0


### PR DESCRIPTION
### Info

* Afterwork of #32 

### Triplets

* `x64-osx`
* `arm64-osx`

```bash
# In Bash
vcpkg install --overlay-triplets ./vcpkg-registry/triplets/ --overlay-ports ./vcpkg-registry/ports/ \
    tensorflow-lite[gpu]:x64-osx tensorflow-lite[gpu]:arm64-osx 
```

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "tensorflow-lite"
            ],
            "baseline": "..."
        }
    ]
}
```
