### PR TITLE
Fix wrong triplet: x64-ios-simulator.cmake

### DIFF
--- a/triplets/x64-ios-simulator.cmake
+++ b/triplets/x64-ios-simulator.cmake
@@ -26,7 +26,7 @@ This triplet is for the minimal works to try iOS Simulator build
 #]===]
 cmake_minimum_required(VERSION 3.13)
 
-set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME iOS)


### PR DESCRIPTION
Fix wrong `VCPKG_TARGET_ARCHITECTURE`. It must be `x64`.

### Triplets

* `x64-ios-simulator`
