### PR TITLE
[tensorflow-lite] port update to v2.7.1

### DIFF
--- a/ports/tensorflow-lite/portfile.cmake
+++ b/ports/tensorflow-lite/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tensorflow/tensorflow
-    REF v2.7.0
-    SHA512 f1e892583c7b3a73d4d39ec65dc135a5b02c789b357d57414ad2b6d05ad9fbfc8ef81918ba6410e314abd6928b76f764e6ef64c0b0c84b58b50796634be03f39
+    REF v2.7.1
+    SHA512 d818f4c2640dd8240cf66c4c64d79fa90508b5c4af3c2e2905b0535fb0fe9c70d3495d8d1e74f7e92c6c6e986ad70855e31147516811a4800a412a927cb398ea
     PATCHES
         fix-cmakelists.patch
         fix-gpu-build.patch

--- a/ports/tensorflow-lite/vcpkg.json
+++ b/ports/tensorflow-lite/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tensorflow-lite",
-  "version-semver": "2.7.0",
-  "port-version": 1,
+  "version-semver": "2.7.1",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://www.tensorflow.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -57,8 +57,8 @@
       "port-version": 1
     },
     "tensorflow-lite": {
-      "baseline": "2.7.0",
-      "port-version": 1
+      "baseline": "2.7.1",
+      "port-version": 0
     },
     "tensorpipe": {
       "baseline": "2021-11-13",

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a28c6b7c825b4fdd38de037eb5eaff15749ba7a7",
+      "version-semver": "2.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ed4dd06af8464675fa876bee6c66273f56fc381",
       "version-semver": "2.7.0",
       "port-version": 1


### PR DESCRIPTION
### Info

* Project: [TensorFlow Lite](https://github.com/tensorflow/tensorflow/releases/tag/v2.7.1)
* 2022/02/03

#### Previous Works
* #39
* #32

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "tensorflow-lite"
            ],
            "baseline": "..."
        }
    ]
}
```
