### PR TITLE
[libdispatch] Support NDK 23+

### DIFF
--- a/ports/libdispatch/portfile.cmake
+++ b/ports/libdispatch/portfile.cmake
@@ -12,6 +12,14 @@ if(VCPKG_TARGET_IS_WINDOWS)
     elseif(TARGET_TRIPLET MATCHES "arm64-windows")
         # ... not tested ...
     endif()
+elseif(VCPKG_TARGET_IS_ANDROID)
+    # check https://github.com/apple/swift-corelibs-libdispatch/pull/568 for the details...
+    vcpkg_download_distfile(NDK23_STDATOMIC_PATCH
+        URLS "https://patch-diff.githubusercontent.com/raw/apple/swift-corelibs-libdispatch/pull/568.diff"
+        FILENAME libdispatch-pr-568.patch
+        SHA512 af23d9530a1c9d10193ab977be632b6393b6966db367c5ee8463ad79fcc2388bed233dcd77439f035b4c4609d99329a17c58fef53cce1a1000a70a41d7406df4
+    )
+    list(APPEND PLATFORM_PATCHES "${NDK23_STDATOMIC_PATCH}")
 endif()
 
 vcpkg_from_github(

--- a/ports/libdispatch/vcpkg.json
+++ b/ports/libdispatch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libdispatch",
   "version-string": "swift-5.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The libdispatch Project, (a.k.a. Grand Central Dispatch), for concurrency on multicore hardware",
   "homepage": "https://github.com/apple/swift-corelibs-libdispatch",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -30,7 +30,7 @@
     },
     "libdispatch": {
       "baseline": "swift-5.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libtorch": {
       "baseline": "1.10.0",

--- a/versions/l-/libdispatch.json
+++ b/versions/l-/libdispatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7eb91c9d37212fc7169e868942abb1e58b46cbab",
+      "version-string": "swift-5.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "2f5c7140da63c9427eb9c48686b914152fd689f8",
       "version-string": "swift-5.5",
       "port-version": 1


### PR DESCRIPTION
Resolve #24 

### Info

* Project: [Apple Swift GCD](apple/swift-corelibs-libdispatch)
* [5.5 (2021/09)](https://github.com/apple/swift-corelibs-libdispatch/releases/tag/swift-5.5-RELEASE)

### Triplets

* `arm64-android`
* `arm-android`
* `x64-android`

`VCPKG_LIBRARY_LINKAGE` can be both `static` and `dynamic`.

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "libdispatch"
            ],
            "baseline": "..."
        }
    ]
}
```

### Related Issues

* https://github.com/apple/swift-corelibs-libdispatch/pull/568 (Special thanks for the PR!)
* #24

#### Previous Work
* #23
* #8