### PR TITLE
[xnvctrl] create a new port

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,7 +168,7 @@ stages:
           vmImage: ubuntu-20.04
         timeoutInMinutes: "300"
         steps:
-          - powershell: sudo apt-get install -y libnuma-dev libopenmpi-dev nasm
+          - powershell: sudo apt-get install -y libnuma-dev libopenmpi-dev nasm libx11-dev libx11-xcb-dev
             displayName: "Install APT packages"
           - powershell: pip install typing-extensions pybind11 numpy pyyaml
             displayName: "Install Python packages"
@@ -179,6 +179,14 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x64-linux
+          - task: run-vcpkg@0
+            displayName: "x64-linux(failure)"
+            inputs:
+              vcpkgArguments: "xnvctrl"
+              vcpkgGitCommitId: $(vcpkg.commit)
+            env:
+              VCPKG_DEFAULT_TRIPLET: x64-linux
+            continueOnError: true
 
       - job: "port_android"
         displayName: "Android"

--- a/ports/xnvctrl/CMakeLists.txt
+++ b/ports/xnvctrl/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.18)
+project(XNVCtrl LANGUAGES C)
+
+find_package(X11 REQUIRED)
+
+add_library(XNVCtrl NVCtrl.c)
+
+set_target_properties(XNVCtrl
+PROPERTIES
+  C_STANDARD 11
+)
+
+target_include_directories(XNVCtrl
+PRIVATE
+  ${X11_INCLUDE_DIR}
+)
+
+target_compile_options(XNVCtrl
+PRIVATE
+  -Wno-format-zero-length -Wno-unused-parameter
+)
+
+target_link_libraries(XNVCtrl
+PRIVATE
+  X11::xcb # /usr/lib/x86_64-linux-gnu/libxcb.so
+)
+
+include(GNUInstallDirs)
+install(FILES NVCtrl.h NVCtrlLib.h nv_control.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(TARGETS XNVCtrl DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/ports/xnvctrl/portfile.cmake
+++ b/ports/xnvctrl/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/nvidia-settings
+    REF 515.43.04 # 7471c5b584c4d8df8d81c336c01b29b8e4b15b1d
+    SHA512 fe4e5013ea90b55a772d504056586b9315d82236a87b77d54b72c540fa10b040553bea2db98017bfdd7c38ef8ba5f8f84e46101b593efd35bad5ace9fa134bb3
+)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+     DESTINATION ${SOURCE_PATH}/src/libXNVCtrl
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}/src/libXNVCtrl)
+vcpkg_cmake_install()
+
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION     ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/doc/NV-CONTROL-API.txt  DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/xnvctrl/vcpkg.json
+++ b/ports/xnvctrl/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "xnvctrl",
+  "version-string": "515.43.04",
+  "description": "NV-CONTROL X Extension",
+  "homepage": "https://github.com/NVIDIA/nvidia-settings",
+  "license": "GPL-2.0",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -72,6 +72,10 @@
       "baseline": "2022-04-23",
       "port-version": 0
     },
+    "xnvctrl": {
+      "baseline": "515.43.04",
+      "port-version": 0
+    },
     "zenny-atomic": {
       "baseline": "2021-10-15",
       "port-version": 0

--- a/versions/x-/xnvctrl.json
+++ b/versions/x-/xnvctrl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "21bbbfb799aedbf75a72ed234b5c1edd61481fa4",
+      "version-string": "515.43.04",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Info

* Project: [NVIDIA/nvidia-settings](https://github.com/NVIDIA/nvidia-settings) libXNVCtrl

[Google/ANGLE](https://github.com/google/angle) is using old version of the library.
The work is using one of the tags, https://github.com/NVIDIA/nvidia-settings/releases/tag/515.43.04
See https://github.com/google/angle/tree/main/src/third_party/libXNVCtrl

### Triplets

* `x64-linux`

Requires X11. APT package `libx11-dev`, `libx11-xcb-dev` will be added.


### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "xnvctrl"
            ],
            "baseline": "..."
        }
    ]
}
```
