### PR TITLE
[tensorflow-lite] Support ios triplets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -263,6 +263,14 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-osx
+          - task: run-vcpkg@0
+            displayName: "arm64-ios-simulator"
+            inputs:
+              vcpkgArguments: "tensorflow-lite[gpu] --debug"
+              vcpkgGitCommitId: $(vcpkg.commit)
+            env:
+              VCPKG_DEFAULT_TRIPLET: arm64-ios-simulator
+              VCPKG_OVERLAY_TRIPLETS: $(Build.SourcesDirectory)/triplets
 
   - stage: "Scripts" # todo: Use of this registry
     jobs:

--- a/ports/tensorflow-lite/fix-cmake-ios.patch
+++ b/ports/tensorflow-lite/fix-cmake-ios.patch
@@ -1,0 +1,30 @@
+diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
+index 758dea9d..7dc15e14 100644
+--- a/tensorflow/lite/CMakeLists.txt
++++ b/tensorflow/lite/CMakeLists.txt
+@@ -221,6 +221,9 @@ else()
+ endif()
+ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "iOS")
+   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_ios\\.cc$")
++else()
++  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_default\\.cc$")
++  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_android\\.cc$")
+ endif()
+ populate_tflite_source_vars("core" TFLITE_CORE_SRCS)
+ populate_tflite_source_vars("core/api" TFLITE_CORE_API_SRCS)
+@@ -570,6 +573,15 @@ if(CMAKE_SYSTEM_NAME MATCHES "Android")
+   list(APPEND TFLITE_PROFILER_SRCS
+     ${TFLITE_SOURCE_DIR}/profiling/atrace_profiler.cc
+   )
++elseif(APPLE)
++  # populate_tflite_source_vars("profiling"
++  #   TFLITE_PROFILER_SRCS
++  #   FILTER ".*(_test|_tester)\\.(cc|h)"
++  # )
++  list(APPEND TFLITE_PROFILER_SRCS
++    ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.h
++    ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.mm
++  )
+ endif()
+ 
+ # Common include directories

--- a/ports/tensorflow-lite/fix-cmake-ios.patch
+++ b/ports/tensorflow-lite/fix-cmake-ios.patch
@@ -21,10 +21,10 @@ index 758dea9d..7dc15e14 100644
 +  #   TFLITE_PROFILER_SRCS
 +  #   FILTER ".*(_test|_tester)\\.(cc|h)"
 +  # )
-+  list(APPEND TFLITE_PROFILER_SRCS
-+    ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.h
-+    ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.mm
-+  )
++  list(APPEND TFLITE_PROFILER_SRCS ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.h ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.mm)
++  add_compile_definitions(TFLITE_ENABLE_DEFAULT_PROFILER)
++  find_library(FOUNDATION_LIBPATH Foundation REQUIRED)
++  link_libraries("-framework Foundation")
  endif()
  
  # Common include directories

--- a/ports/tensorflow-lite/portfile.cmake
+++ b/ports/tensorflow-lite/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake.patch
         fix-cmake-gpu.patch
+        fix-cmake-ios.patch
         fix-source.patch
         fix-source-gpu.patch
 )
@@ -27,7 +28,7 @@ find_program(PROTOC_EXECUTABLE NAMES protoc
 message(STATUS "Using protoc: ${PROTOC_EXECUTABLE}")
 
 if("gpu" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_OSX) # .proto files for coreml_mlmodel_codegen
+    if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS) # .proto files for coreml_mlmodel_codegen
         vcpkg_from_github(
             OUT_SOURCE_PATH COREML_SOURCE_PATH
             REPO apple/coremltools
@@ -146,10 +147,10 @@ if("gpu" IN_LIST FEATURES)
     )
 else()
     # remove unsupported delegated for each target platform
-    if(NOT DEFINED VCPKG_TARGET_IS_OSX OR NOT VCPKG_TARGET_IS_OSX)
+    if((NOT VCPKG_TARGET_IS_IOS) AND (NOT VCPKG_TARGET_IS_OSX))
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/tensorflow/lite/delegates/coreml")
     endif()
-    if(NOT DEFINED VCPKG_TARGET_IS_ANDROID OR NOT VCPKG_TARGET_IS_ANDROID)
+    if(NOT VCPKG_TARGET_IS_ANDROID)
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/tensorflow/lite/nnapi"
                             "${CURRENT_PACKAGES_DIR}/include/tensorflow/lite/delegates/nnapi"
         )

--- a/ports/tensorflow-lite/vcpkg.json
+++ b/ports/tensorflow-lite/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "tensorflow-lite",
   "version-semver": "2.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://www.tensorflow.org/",
   "license": "Apache-2.0",
-  "supports": "!ios",
   "dependencies": [
     "abseil",
     "eigen3",
@@ -45,7 +44,7 @@
         "opengl-registry",
         {
           "name": "protobuf",
-          "platform": "osx"
+          "platform": "osx | ios"
         },
         "vulkan-headers"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -58,7 +58,7 @@
     },
     "tensorflow-lite": {
       "baseline": "2.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tensorpipe": {
       "baseline": "2021-11-13",

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f55e082dabc3092de0d709dc0dd5ff304ed8f230",
+      "version-semver": "2.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "bc754f77f9acc153cac6d5d8568c089aa668d3d6",
       "version-semver": "2.8.0",
       "port-version": 1


### PR DESCRIPTION
### Info

* Project: [TensorFlow Lite v2.8.0](https://github.com/tensorflow/tensorflow/releases/tag/v2.8.0)
* 2022/02/03

#### Previous Works

* #46 
* #47

### Triplets

* `arm64-ios`
* `arm64-ios-simulator`

