### PR TITLE
[zlib-ng] update to 2.0.6

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -1,16 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/zlib-ng
-    REF 2.0.5
-    SHA512 a643089a8189bf8bd24d679b84f07ae14932b4d88b88e94c44cca23350d6a9bbdaa411822d3651c2b0bf79f30c9f99514cc252cf9e9ab0b3a840540206466654
+    REF 2.0.6
+    SHA512 4888f17160d0a87a9b349704047ae0d0dc57237a10e11adae09ace957afa9743cce5191db67cb082991421fc961ce68011199621034d2369c0e7724fad58b4c5
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        zlib-compat ZLIB_COMPAT # When OFF, "-ng" suffix will remain
+)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DZLIB_COMPAT=OFF # "-ng" suffix will remain
-        -DZLIB_FULL_VERSION=2.0.5
+        ${FEATURE_OPTIONS}
+        -DZLIB_FULL_VERSION=2.0.6
         -DZLIB_ENABLE_TESTS=OFF
         -DWITH_NEW_STRATEGIES=ON
         -DWITH_NATIVE_INSTRUCTIONS=OFF # `-march=native` breaks `check_c_source_compiles`
@@ -21,9 +26,9 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig() # zlib-ng>=2.0
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
-                    ${CURRENT_PACKAGES_DIR}/debug/include
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
 )
-file(INSTALL ${SOURCE_PATH}/LICENSE.md
-     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.md"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright
 )

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zlib-ng",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "zlib replacement with optimizations for 'next generation' systems",
   "homepage": "https://github.com/zlib-ng/zlib-ng",
   "license": "Zlib",
@@ -9,5 +9,10 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "zlib-compat": {
+      "description": "Use compatible name with ZLIB"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -81,7 +81,7 @@
       "port-version": 0
     },
     "zlib-ng": {
-      "baseline": "2.0.5",
+      "baseline": "2.0.6",
       "port-version": 0
     }
   }

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1775e53af13daa53388baa410f0cd649d260a1da",
+      "version": "2.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "9951d88af275836acfd81ea6496f14098c732b83",
       "version": "2.0.5",
       "port-version": 0


### PR DESCRIPTION
### Info

* Project: https://github.com/zlib-ng/zlib-ng
* 2021/12/24

### Triplets

Most of the triplets

```ps1
vcpkg install --overlay-ports "./vcpkg-registry/ports/"  zlib-ng[zlib-compat]
```
### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "zlib-ng"
            ],
            "baseline": "..."
        }
    ]
}
```
