### PR TITLE
[openssl3] update to 3.0.4

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.0.1
-    SHA512 7f303769a3a796b88478399d42aa2a9a70dc74f62c975bbb93e8903e3bb8e25f16ecfc436186c2d4aa7383302c73ad1dd8ac4fccaa589062bbce6059d6073f18
+    REF openssl-3.0.4
+    SHA512 c58b439addbfc0901cb8d99036494bac60d24a4311815b9b7a559f5daaa027d4b83e49e2eb526f0552ec53f09be89081a08c20b8b6f20a2463081cdb071d6faf
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.0.1",
+  "version-semver": "3.0.4",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -49,7 +49,7 @@
       "port-version": 1
     },
     "openssl3": {
-      "baseline": "3.0.1",
+      "baseline": "3.0.4",
       "port-version": 0
     },
     "ruy": {

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be2eae6fa85a1d69f456f34f239a07611792e2af",
+      "version-semver": "3.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "989acb7f35a4fcdd11a4fbde6f80e0d52f23c53f",
       "version-semver": "3.0.1",
       "port-version": 0


### PR DESCRIPTION
### Info

* Project: [OpenSSL 3.0.4](https://github.com/openssl/openssl/releases/tag/openssl-3.0.4)
* 2022/06

### Triplets

Most of the triplets.

```ps1
vcpkg install --overlay-ports "./vcpkg-registry/ports/ " openssl3
```

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl3"
            ],
            "baseline": "..."
        }
    ]
}
```
