### PR TITLE
[onnx,onnxruntime] update to later release  

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,7 +127,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "x86-windows"
             inputs:
-              vcpkgArguments: "cpuinfo gemmlowp farmhash openssl3 tensorflow-lite libdispatch zlib-ng directml fft2d"
+              vcpkgArguments: "cpuinfo gemmlowp farmhash openssl3 onnxruntime[directml] tensorflow-lite libdispatch zlib-ng directml fft2d"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x86-windows
@@ -181,7 +181,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "x64-linux"
             inputs:
-              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 tensorpipe tensorflow-lite zlib-ng directml fft2d"
+              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 onnxruntime tensorpipe tensorflow-lite zlib-ng directml fft2d"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x64-linux
@@ -251,7 +251,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "x64-osx"
             inputs:
-              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 tensorpipe tensorflow-lite[gpu] xnnpack zlib-ng metal-cpp fft2d"
+              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 onnxruntime[coreml] tensorpipe tensorflow-lite[gpu] xnnpack zlib-ng metal-cpp fft2d"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x64-osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
       - job: "port_windows"
         displayName: "Windows"
         pool:
-          vmImage: windows-2019
+          vmImage: windows-2022
         steps:
           - task: UsePythonVersion@0
             displayName: "Setup: Python 3.10"
@@ -109,12 +109,27 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-windows
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/"
+              Contents: |
+                ?(*.log|*.txt)
+                *.cmake
+              TargetFolder: "$(Build.ArtifactStagingDirectory)"
+              OverWrite: true
+            condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Staged Logs"
+            inputs:
+              PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+              ArtifactName: "$(Agent.JobName)"
+            condition: always()
         timeoutInMinutes: "300"
 
       - job: "port_windows_32"
         displayName: "Windows(32bit)"
         pool:
-          vmImage: windows-2019
+          vmImage: windows-2022
         steps:
           - task: UsePythonVersion@0
             displayName: "Setup: Python 3.10"
@@ -138,12 +153,27 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm-windows
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/"
+              Contents: |
+                ?(*.log|*.txt)
+                *.cmake
+              TargetFolder: "$(Build.ArtifactStagingDirectory)"
+              OverWrite: true
+            condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Staged Logs"
+            inputs:
+              PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+              ArtifactName: "$(Agent.JobName)"
+            condition: always()
         timeoutInMinutes: "300"
 
       - job: "port_uwp"
         displayName: "Windows(UWP)"
         pool:
-          vmImage: windows-2019
+          vmImage: windows-2022
         steps:
           - task: UsePythonVersion@0
             displayName: "Setup: Python 3.10"
@@ -193,6 +223,21 @@ stages:
             env:
               VCPKG_DEFAULT_TRIPLET: x64-linux
             continueOnError: true
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/"
+              Contents: |
+                ?(*.log|*.txt)
+                *.cmake
+              TargetFolder: "$(Build.ArtifactStagingDirectory)"
+              OverWrite: true
+            condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Staged Logs"
+            inputs:
+              PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+              ArtifactName: "$(Agent.JobName)"
+            condition: always()
         timeoutInMinutes: "300"
 
       - job: "port_android"
@@ -285,6 +330,21 @@ stages:
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-ios-simulator
               VCPKG_OVERLAY_TRIPLETS: $(Build.SourcesDirectory)/triplets
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/"
+              Contents: |
+                ?(*.log|*.txt)
+                *.cmake
+              TargetFolder: "$(Build.ArtifactStagingDirectory)"
+              OverWrite: true
+            condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Staged Logs"
+            inputs:
+              PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+              ArtifactName: "$(Agent.JobName)"
+            condition: always()
         timeoutInMinutes: "300"
 
   # todo: Deploy stage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,7 @@ stages:
               VCPKG_DEFAULT_TRIPLET: arm-windows
           - task: CopyFiles@2
             inputs:
-              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/"
+              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/onnxruntime"
               Contents: |
                 ?(*.log|*.txt)
                 *.cmake
@@ -225,7 +225,7 @@ stages:
             continueOnError: true
           - task: CopyFiles@2
             inputs:
-              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/"
+              SourceFolder: "$(Build.BinariesDirectory)/vcpkg/buildtrees/onnxruntime"
               Contents: |
                 ?(*.log|*.txt)
                 *.cmake

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,12 +222,12 @@ stages:
           - task: run-vcpkg@0
             displayName: "Default Triplet"
             inputs:
-              vcpkgArguments: "cpuinfo openssl3 xnnpack onnxruntime[xnnpack] zlib-ng libdispatch fft2d farmhash ruy eigen3"
+              vcpkgArguments: "openssl3 zlib-ng libdispatch fft2d farmhash ruy eigen3"
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: run-vcpkg@0
             displayName: "Custom Triplet"
             inputs:
-              vcpkgArguments: "tensorflow-lite[gpu]"
+              vcpkgArguments: "onnxruntime[xnnpack] tensorflow-lite[gpu]"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_OVERLAY_TRIPLETS: $(Build.SourcesDirectory)/triplets

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,7 +127,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "x86-windows"
             inputs:
-              vcpkgArguments: "cpuinfo gemmlowp farmhash openssl3 onnxruntime[directml] tensorflow-lite libdispatch zlib-ng directml fft2d"
+              vcpkgArguments: "cpuinfo gemmlowp farmhash openssl3 onnxruntime[xnnpack,directml] tensorflow-lite libdispatch zlib-ng directml fft2d"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x86-windows
@@ -181,7 +181,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "x64-linux"
             inputs:
-              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 onnxruntime tensorpipe tensorflow-lite zlib-ng directml fft2d"
+              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 onnxruntime[xnnpack] tensorpipe tensorflow-lite zlib-ng directml fft2d"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x64-linux
@@ -222,7 +222,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "Default Triplet"
             inputs:
-              vcpkgArguments: "cpuinfo openssl3 xnnpack zlib-ng libdispatch fft2d farmhash ruy eigen3"
+              vcpkgArguments: "cpuinfo openssl3 xnnpack onnxruntime[xnnpack] zlib-ng libdispatch fft2d farmhash ruy eigen3"
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: run-vcpkg@0
             displayName: "Custom Triplet"
@@ -251,7 +251,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "x64-osx"
             inputs:
-              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 onnxruntime[coreml] tensorpipe tensorflow-lite[gpu] xnnpack zlib-ng metal-cpp fft2d"
+              vcpkgArguments: "gemmlowp cpuinfo farmhash openssl3 onnxruntime[xnnpack,coreml] tensorpipe tensorflow-lite[gpu] xnnpack zlib-ng metal-cpp fft2d"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: x64-osx
@@ -273,7 +273,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "arm64-osx"
             inputs:
-              vcpkgArguments: "gemmlowp cpuinfo openssl3 zlib-ng metal-cpp fft2d farmhash tensorflow-lite[gpu]"
+              vcpkgArguments: "gemmlowp cpuinfo openssl3 onnxruntime[xnnpack,coreml] zlib-ng metal-cpp fft2d farmhash tensorflow-lite[gpu]"
               vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-osx

--- a/ports/cpuinfo/portfile.cmake
+++ b/ports/cpuinfo/portfile.cmake
@@ -1,6 +1,8 @@
 # On Windows, we can get a cpuinfo.dll, but it exports no symbols.
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+elseif(VCPKG_TARGET_IS_LINUX)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
 vcpkg_from_github(

--- a/ports/cpuinfo/vcpkg.json
+++ b/ports/cpuinfo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpuinfo",
   "version-date": "2022-09-08",
+  "port-version": 1,
   "description": "CPU INFOrmation library (x86/x86-64/ARM/ARM64, Linux/Windows/Android/macOS/iOS)",
   "homepage": "https://github.com/pytorch/cpuinfo",
   "license": "BSD-2-Clause",

--- a/ports/onnx/fix-cmakelists.patch
+++ b/ports/onnx/fix-cmakelists.patch
@@ -1,44 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 628dcaa..300e4ea 100644
+index f914e78..9644877 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -111,8 +111,8 @@ endif()
- # find_package Python has replaced PythonInterp and PythonLibs since cmake 3.12
- # Use the following command in the future; now this is only compatible with the latest pybind11
- # find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
--find_package(PythonInterp ${PY_VERSION} REQUIRED)
--find_package(PythonLibs ${PY_VERSION})
-+find_package(Python3 ${PY_VERSION} COMPONENTS Interpreter REQUIRED)
-+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
- 
- if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
-   set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
-@@ -422,6 +422,7 @@ target_link_libraries(onnx PUBLIC onnx_proto)
- add_onnx_global_defines(onnx)
- 
- if(BUILD_ONNX_PYTHON)
-+  find_package(Python3 ${PY_VERSION} COMPONENTS Development REQUIRED)
-   if("${PY_EXT_SUFFIX}" STREQUAL "")
-     if(MSVC)
-       set(PY_EXT_SUFFIX ".pyd")
-@@ -441,10 +442,13 @@ if(BUILD_ONNX_PYTHON)
-                              $<BUILD_INTERFACE:${ONNX_ROOT}>
-                              $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                              $<INSTALL_INTERFACE:include>
--                             ${PYTHON_INCLUDE_DIR})
--
-+                             ${Python3_INCLUDE_DIRS})
-+  target_link_directories(onnx_cpp2py_export PRIVATE
-+                          ${Python3_LIBRARY_DIRS})
-+  target_link_libraries(onnx_cpp2py_export PRIVATE
-+                        ${Python3_LIBRARIES})
-   # pybind11 is a header only lib
--  find_package(pybind11 2.2)
-+  find_package(pybind11 2.2 CONFIG REQUIRED)
-   if(pybind11_FOUND)
-     target_include_directories(onnx_cpp2py_export PUBLIC
-       ${pybind11_INCLUDE_DIRS})
-@@ -687,6 +691,27 @@ endif()
+@@ -666,6 +666,27 @@ endif()
  
  include(GNUInstallDirs)
  
@@ -66,21 +30,3 @@ index 628dcaa..300e4ea 100644
  install(DIRECTORY ${ONNX_ROOT}/onnx
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
          FILES_MATCHING
-@@ -639,7 +639,7 @@ endif()
- 
- if (NOT ANDROID AND NOT IOS)
-   # ---[ ONNXIFI wrapper
--  add_library(onnxifi_wrapper MODULE onnx/onnxifi_wrapper.c)
-+  add_library(onnxifi_wrapper onnx/onnxifi_wrapper.c)
-   if(MSVC)
-     add_msvc_runtime_flag(onnxifi_wrapper)
-   endif()
-@@ -669,7 +669,7 @@ if (NOT ANDROID AND NOT IOS)
- endif()
- 
- # ---[ ONNXIFI dummy backend
--add_library(onnxifi_dummy SHARED onnx/onnxifi_dummy.c)
-+add_library(onnxifi_dummy onnx/onnxifi_dummy.c)
- 
- if(ONNXIFI_ENABLE_EXT)
-   add_definitions(-DONNXIFI_ENABLE_EXT=ON)

--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -1,12 +1,10 @@
-# uwp: LOAD_LIBRARY_SEARCH_DEFAULT_DIRS undefined identifier
-vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onnx/onnx
-    REF v1.10.2
-    SHA512 7519d326cd2b2b13a269ec0d01af07c32115d183dae6e1eaae55f5b23b6c92b2aadbb2b1e555557f4201bbcf921fa563d09d45d7f1d3bd2399c1a94a6ef63303
+    REF v1.12.0
+    SHA512 ab0c4f92358e904c2f28d98b35eab2d6eac22dd0a270e4f45ee590aa1ad22d09e92b32225efd7e98edb1531743f150526d26e0cbdc537757784bef2bc93efa8e
     PATCHES
         fix-cmakelists.patch
 )
@@ -14,75 +12,83 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_RUNTIME)
 
 # ONNX_USE_PROTOBUF_SHARED_LIBS: find the library and check its file extension
-find_library(PROTOBUF_LIBPATH NAMES protobuf PATHS ${CURRENT_INSTALLED_DIR}/bin ${CURRENT_INSTALLED_DIR}/lib REQUIRED)
-get_filename_component(PROTOBUF_LIBNAME ${PROTOBUF_LIBPATH} NAME)
-if(PROTOBUF_LIBNAME MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+find_library(PROTOBUF_LIBPATH NAMES protobuf PATHS "${CURRENT_INSTALLED_DIR}/bin" "${CURRENT_INSTALLED_DIR}/lib" REQUIRED)
+get_filename_component(PROTOBUF_LIBNAME "${PROTOBUF_LIBPATH}" NAME)
+if(PROTOBUF_LIBNAME MATCHES "${CMAKE_SHARED_LIBRARY_SUFFIX}")
     set(USE_PROTOBUF_SHARED ON)
 else()
     set(USE_PROTOBUF_SHARED OFF)
 endif()
+find_program(PROTOC_EXECUTABLE NAMES protoc PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf" REQUIRED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        pybind11      BUILD_ONNX_PYTHON
-        protobuf-lite ONNX_USE_LITE_PROTO
+        pybind11 BUILD_ONNX_PYTHON
 )
 
 # Like protoc, python is required for codegen.
 vcpkg_find_acquire_program(PYTHON3)
 
 # PATH for .bat scripts so it can find 'python'
-get_filename_component(PYTHON_DIR ${PYTHON3} PATH)
-vcpkg_add_to_path(PREPEND ${PYTHON_DIR})
+get_filename_component(PYTHON_DIR "${PYTHON3}" PATH)
+vcpkg_add_to_path(PREPEND "${PYTHON_DIR}")
+
+if("pybind11" IN_LIST FEATURES)
+    # When BUILD_ONNX_PYTHON, we need Development component. Give a hint for FindPython3
+    list(APPEND FEATURE_OPTIONS
+        "-DPython3_ROOT_DIR=${CURRENT_INSTALLED_DIR}"
+    )
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DPython3_EXECUTABLE=${PYTHON3}
+        -DPYTHON_EXECUTABLE=${PYTHON3}
+        -DProtobuf_PROTOC_EXECUTABLE=${PROTOC_EXECUTABLE}
+        -DONNX_CUSTOM_PROTOC_EXECUTABLE=${PROTOC_EXECUTABLE}
         -DONNX_ML=ON
         -DONNX_GEN_PB_TYPE_STUBS=ON
         -DONNX_USE_PROTOBUF_SHARED_LIBS=${USE_PROTOBUF_SHARED}
+        -DONNX_USE_LITE_PROTO=OFF
         -DONNX_USE_MSVC_STATIC_RUNTIME=${USE_STATIC_RUNTIME}
         -DONNX_BUILD_TESTS=OFF
         -DONNX_BUILD_BENCHMARKS=OFF
     MAYBE_UNUSED_VARIABLES
         ONNX_USE_MSVC_STATIC_RUNTIME
+        ONNX_CUSTOM_PROTOC_EXECUTABLE
 )
 
-if("pybind11" IN_LIST FEATURES)
-    # This target is not in install/export
-    vcpkg_cmake_build(TARGET onnx_cpp2py_export)
-endif()
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX)
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
-                    "${CURRENT_PACKAGES_DIR}/debug/share"
-                    # the others are empty
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_ml"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_data"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_operators_ml"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_cpp2py_export"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/backend"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/tools"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/test"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/bin"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/examples"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/frontend"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/controlflow"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/generator"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/logical"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/math"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/nn"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/object_detection"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/optional"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/quantization"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/reduction"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/rnn"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/sequence"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/traditionalml"
-                    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/training"
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    # the others are empty
+    "${CURRENT_PACKAGES_DIR}/include/onnx/backend"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/bin"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/controlflow"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/generator"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/logical"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/math"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/nn"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/object_detection"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/optional"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/quantization"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/reduction"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/rnn"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/sequence"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/traditionalml"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/training"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/examples"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/frontend"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_cpp2py_export"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/test"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/tools"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_ml"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_data"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_operators_ml"
 )

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "onnx",
-  "version-semver": "1.10.2",
+  "version-semver": "1.12.0",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",
@@ -19,13 +19,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "protobuf-lite": {
-      "description": "Use lite protobuf instead of full"
-    },
-    "pybind11": {
-      "description": "Build Python binaries"
-    }
-  }
+  ]
 }

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",
-  "supports": "!uwp",
   "dependencies": [
     "protobuf",
     {

--- a/ports/onnxruntime/fix-cmake.patch
+++ b/ports/onnxruntime/fix-cmake.patch
@@ -168,3 +168,63 @@ index 77eac4b..b2b94a8 100644
    else()
      message(FATAL_ERROR "onnxruntime_providers_rocm unknown platform, need to specify shared library exports for it")
    endif()
+diff --git a/cmake/external/xnnpack.cmake b/cmake/external/xnnpack.cmake
+index 25e63ea..dc09bb8 100644
+--- a/cmake/external/xnnpack.cmake
++++ b/cmake/external/xnnpack.cmake
+@@ -1,27 +1,11 @@
+-set(XNNPACK_DIR external/XNNPACK)
+-set(XNNPACK_INCLUDE_DIR ${XNNPACK_DIR}/include)
+-set(XNNPACK_USE_SYSTEM_LIBS ON CACHE INTERNAL "")
+-set(XNNPACK_BUILD_TESTS OFF CACHE INTERNAL "")
+-set(XNNPACK_BUILD_BENCHMARKS OFF CACHE INTERNAL "")
+-set(FP16_BUILD_TESTS OFF CACHE INTERNAL "")
+-set(FP16_BUILD_BENCHMARKS OFF CACHE INTERNAL "")
+-set(CLOG_SOURCE_DIR "${PYTORCH_CPUINFO_DIR}/deps/clog")
+-set(CPUINFO_SOURCE_DIR ${PYTORCH_CPUINFO_DIR})
+-
+ if (onnxruntime_BUILD_WEBASSEMBLY)
+   execute_process(COMMAND  git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenSupport.patch WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${XNNPACK_DIR})
+ endif()
+ 
+-add_subdirectory(external/FP16)
+-add_subdirectory(external/pthreadpool)
+-add_subdirectory(external/XNNPACK)
+-
+-set_target_properties(fp16 PROPERTIES FOLDER "External/Xnnpack")
+-set_target_properties(pthreadpool PROPERTIES FOLDER "External/Xnnpack")
+-set_target_properties(XNNPACK PROPERTIES FOLDER "External/Xnnpack")
++find_package(unofficial-pthreadpool CONFIG REQUIRED) # unofficial::pthreadpool
++find_package(xnnpack CONFIG REQUIRED) # xnnpack
+ 
+-set(onnxruntime_EXTERNAL_LIBRARIES_XNNPACK XNNPACK pthreadpool)
+-list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK})
++list(APPEND onnxruntime_EXTERNAL_LIBRARIES_XNNPACK xnnpack unofficial::pthreadpool)
+ 
+ # the XNNPACK CMake setup doesn't include the WASM kernels so we have to manually set those up
+ if (onnxruntime_BUILD_WEBASSEMBLY)
+diff --git a/cmake/onnxruntime_providers.cmake b/cmake/onnxruntime_providers.cmake
+index b2b94a8..99885a6 100644
+--- a/cmake/onnxruntime_providers.cmake
++++ b/cmake/onnxruntime_providers.cmake
+@@ -1521,7 +1521,7 @@ if (onnxruntime_USE_XNNPACK)
+   source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_providers_xnnpack_cc_srcs})
+   onnxruntime_add_static_library(onnxruntime_providers_xnnpack ${onnxruntime_providers_xnnpack_cc_srcs})
+   onnxruntime_add_include_to_target(onnxruntime_providers_xnnpack
+-    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} XNNPACK pthreadpool
++    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} xnnpack unofficial::pthreadpool
+   )
+ 
+   add_dependencies(onnxruntime_providers_xnnpack onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
+diff --git a/cmake/onnxruntime_providers.cmake b/cmake/onnxruntime_providers.cmake
+index 99885a6..6fe1263 100644
+--- a/cmake/onnxruntime_providers.cmake
++++ b/cmake/onnxruntime_providers.cmake
+@@ -1523,6 +1523,7 @@ if (onnxruntime_USE_XNNPACK)
+   onnxruntime_add_include_to_target(onnxruntime_providers_xnnpack
+     onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} xnnpack unofficial::pthreadpool
+   )
++  target_link_libraries(onnxruntime_providers_xnnpack PUBLIC xnnpack unofficial::pthreadpool cpuinfo::cpuinfo)
+ 
+   add_dependencies(onnxruntime_providers_xnnpack onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
+   set_target_properties(onnxruntime_providers_xnnpack PROPERTIES FOLDER "ONNXRuntime")

--- a/ports/onnxruntime/fix-cmake.patch
+++ b/ports/onnxruntime/fix-cmake.patch
@@ -1,62 +1,29 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 2534b99..377653e 100644
+index fb4899d..e148119 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -833,22 +833,27 @@ get_filename_component(ORTTRAINING_ROOT "${ORTTRAINING_ROOT}" ABSOLUTE)
- get_filename_component(REPO_ROOT "${REPO_ROOT}" ABSOLUTE)
- set(ONNXRUNTIME_INCLUDE_DIR ${REPO_ROOT}/include/onnxruntime)
- 
--add_subdirectory(external/date EXCLUDE_FROM_ALL)
-+# add_subdirectory(external/date EXCLUDE_FROM_ALL)
-+find_package(date CONFIG REQUIRED) # date::date date::date-tz
- 
- set(SAFEINT_INCLUDE_DIR ${REPO_ROOT}/cmake/external/SafeInt)
- add_library(safeint_interface INTERFACE)
+@@ -869,8 +869,7 @@ add_library(safeint_interface INTERFACE)
  target_include_directories(safeint_interface INTERFACE ${SAFEINT_INCLUDE_DIR})
  
--set(OPTIONAL_LITE_INCLUDE_DIR ${REPO_ROOT}/cmake/external/optional-lite/include)
-+# set(OPTIONAL_LITE_INCLUDE_DIR ${REPO_ROOT}/cmake/external/optional-lite/include)
-+find_package(optional-lite CONFIG REQUIRED)
-+link_libraries(nonstd::optional-lite) # todo: remove this
- if(onnxruntime_DISABLE_EXCEPTIONS)
-   add_compile_definitions(optional_CONFIG_NO_EXCEPTIONS=1)
+ if (onnxruntime_PREFER_SYSTEM_LIB)
+-  find_package(boost_mp11)
+-  find_package(Boost)
++  find_package(Boost REQUIRED)
+   if (TARGET Boost::boost AND NOT TARGET Boost::mp11)
+     add_library(Boost::mp11 ALIAS Boost::boost)
+   endif()
+@@ -1559,19 +1558,30 @@ else()
+   set(ONNX_USE_LITE_PROTO OFF CACHE BOOL "" FORCE)
  endif()
  
--add_subdirectory(external/mp11 EXCLUDE_FROM_ALL)
-+# add_subdirectory(external/mp11 EXCLUDE_FROM_ALL)
-+find_package(Boost REQUIRED) # Boost::headers
- 
--set(JSON_BuildTests OFF CACHE INTERNAL "")
--set(JSON_Install OFF CACHE INTERNAL "")
--add_subdirectory(external/json EXCLUDE_FROM_ALL)
-+# set(JSON_BuildTests OFF CACHE INTERNAL "")
-+# set(JSON_Install OFF CACHE INTERNAL "")
-+# add_subdirectory(external/json EXCLUDE_FROM_ALL)
-+find_package(nlohmann_json CONFIG REQUIRED) # nlohmann_json::nlohmann_json
- 
- if(onnxruntime_PREFER_SYSTEM_LIB)
-   find_package(re2)
-@@ -895,7 +900,9 @@ else()
- endif()
- 
- # TODO  do we have to add target_include_directories to each project that uses this?
--if(CPUINFO_SUPPORTED)
-+find_package(cpuinfo CONFIG REQUIRED) # cpuinfo::clog cpuinfo::cpuinfo
-+add_library(cpuinfo ALIAS cpuinfo::cpuinfo)
-+if(FALSE)
-   set(PYTORCH_CPUINFO_DIR external/pytorch_cpuinfo)
-   set(PYTORCH_CPUINFO_INCLUDE_DIR ${PYTORCH_CPUINFO_DIR}/include)
-   set(CPUINFO_BUILD_TOOLS OFF CACHE INTERNAL "")
-@@ -1380,18 +1387,18 @@ else()
- endif()
- 
- if (NOT onnxruntime_MINIMAL_BUILD)
+-if (NOT onnxruntime_MINIMAL_BUILD)
 -  add_subdirectory(external/onnx EXCLUDE_FROM_ALL)
-+  # add_subdirectory(external/onnx EXCLUDE_FROM_ALL)
-+  find_package(ONNX CONFIG REQUIRED) # onnx onnxifi onnx_proto
- else()
-   include(onnx_minimal)
- endif()
+-else()
+-  include(onnx_minimal)
+-endif()
++find_path(ONNX_INCLUDE_DIR NAMES "onnx/common/version.h" REQUIRED)
++find_library(ONNX_LIBRARY NAMES onnx REQUIRED)
++find_library(ONNX_PROTO_LIBRARY NAMES onnx_proto REQUIRED)
  
 -target_compile_definitions(onnx PUBLIC $<TARGET_PROPERTY:onnx_proto,INTERFACE_COMPILE_DEFINITIONS> PRIVATE "__ONNX_DISABLE_STATIC_REGISTRATION")
 -if (NOT onnxruntime_USE_FULL_PROTOBUF)
@@ -64,615 +31,140 @@ index 2534b99..377653e 100644
 -endif()
 -set_target_properties(onnx PROPERTIES FOLDER "External/ONNX")
 -set_target_properties(onnx_proto PROPERTIES FOLDER "External/ONNX")
--
-+# target_compile_definitions(onnx PUBLIC $<TARGET_PROPERTY:onnx_proto,INTERFACE_COMPILE_DEFINITIONS> PRIVATE "__ONNX_DISABLE_STATIC_REGISTRATION")
-+# if (NOT onnxruntime_USE_FULL_PROTOBUF)
-+#   target_compile_definitions(onnx PUBLIC "__ONNX_NO_DOC_STRINGS")
-+# endif()
-+# set_target_properties(onnx PROPERTIES FOLDER "External/ONNX")
-+# set_target_properties(onnx_proto PROPERTIES FOLDER "External/ONNX")
++add_library(onnx STATIC IMPORTED GLOBAL)
++set_target_properties(onnx
++PROPERTIES
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNX_INCLUDE_DIR}"
++  INTERFACE_COMPILE_DEFINITIONS "ONNX_ML"
++  IMPORTED_IMPLIB "${ONNX_LIBRARY}"
++  IMPORTED_LOCATION "${ONNX_LIBRARY}"
++)
+ 
++add_library(onnx_proto STATIC IMPORTED GLOBAL)
++set_target_properties(onnx_proto
++PROPERTIES
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNX_INCLUDE_DIR}"
++  INTERFACE_COMPILE_DEFINITIONS "ONNX_ML"
++  IMPORTED_IMPLIB "${ONNX_PROTO_LIBRARY}"
++  IMPORTED_LOCATION "${ONNX_PROTO_LIBRARY}"
++)
++if(TRUE)
++  add_compile_definitions(ONNX_NAMESPACE=onnx ONNX_ML=1)
++endif()
  
  # fix a warning in onnx code we can't do anything about
  if (MSVC)
-@@ -1414,10 +1421,11 @@ set(FLATBUFFERS_INSTALL OFF CACHE BOOL "FLATBUFFERS_INSTALL" FORCE)
- set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "FLATBUFFERS_BUILD_FLATHASH" FORCE)
- set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "FLATBUFFERS_BUILD_FLATLIB" FORCE)
- set_msvc_c_cpp_compiler_warning_level(4)
--add_subdirectory(external/flatbuffers EXCLUDE_FROM_ALL)
-+# add_subdirectory(external/flatbuffers EXCLUDE_FROM_ALL)
-+find_package(Flatbuffers CONFIG REQUIRED)
- set_msvc_c_cpp_compiler_warning_level(3)
--list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES flatbuffers)
--list(APPEND onnxruntime_EXTERNAL_LIBRARIES flatbuffers)
-+list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES flatbuffers::flatbuffers)
-+list(APPEND onnxruntime_EXTERNAL_LIBRARIES flatbuffers::flatbuffers)
- 
- if (CMAKE_SYSTEM_NAME STREQUAL "Android" AND Onnxruntime_GCOV_COVERAGE)
-   string(APPEND CMAKE_CXX_FLAGS " -g -O0 --coverage ")
-diff --git a/cmake/external/eigen.cmake b/cmake/external/eigen.cmake
-index 264247a..9fbd72d 100644
---- a/cmake/external/eigen.cmake
-+++ b/cmake/external/eigen.cmake
-@@ -1,9 +1,11 @@
- include (ExternalProject)
- 
- if (onnxruntime_USE_PREINSTALLED_EIGEN)
--    add_library(eigen INTERFACE)
--    file(TO_CMAKE_PATH ${eigen_SOURCE_PATH} eigen_INCLUDE_DIRS)
--    target_include_directories(eigen INTERFACE ${eigen_INCLUDE_DIRS})
-+    find_package(Eigen3 CONFIG REQUIRED)
-+    link_libraries(Eigen3::Eigen) # todo: remove this
-+    # add_library(eigen INTERFACE)
-+    # file(TO_CMAKE_PATH ${eigen_SOURCE_PATH} eigen_INCLUDE_DIRS)
-+    # target_include_directories(eigen INTERFACE ${eigen_INCLUDE_DIRS})
- else ()
-     if (onnxruntime_USE_ACL)
-         execute_process(COMMAND  git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/eigen/Fix_Eigen_Build_Break.patch WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-diff --git a/cmake/onnxruntime_codegen.cmake b/cmake/onnxruntime_codegen.cmake
-index 93ce4a2..11e431c 100644
---- a/cmake/onnxruntime_codegen.cmake
-+++ b/cmake/onnxruntime_codegen.cmake
-@@ -19,7 +19,7 @@ source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_codegen_common_sr
- onnxruntime_add_static_library(onnxruntime_codegen_tvm ${onnxruntime_codegen_common_srcs} ${onnxruntime_codegen_tvm_srcs})
- set_target_properties(onnxruntime_codegen_tvm PROPERTIES FOLDER "ONNXRuntime")
- target_include_directories(onnxruntime_codegen_tvm PRIVATE ${ONNXRUNTIME_ROOT} ${TVM_INCLUDES} ${MKLML_INCLUDE_DIR} ${eigen_INCLUDE_DIRS})
--onnxruntime_add_include_to_target(onnxruntime_codegen_tvm onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_codegen_tvm onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- target_compile_options(onnxruntime_codegen_tvm PRIVATE ${DISABLED_WARNINGS_FOR_TVM})
- # need onnx to build to create headers that this project includes
- add_dependencies(onnxruntime_codegen_tvm ${onnxruntime_EXTERNAL_DEPENDENCIES})
 diff --git a/cmake/onnxruntime_common.cmake b/cmake/onnxruntime_common.cmake
-index 4786ddb..bd33b34 100644
+index a8ca9c9..1dfbf77 100644
 --- a/cmake/onnxruntime_common.cmake
 +++ b/cmake/onnxruntime_common.cmake
-@@ -100,14 +100,14 @@ if (onnxruntime_USE_MIMALLOC_STL_ALLOCATOR OR onnxruntime_USE_MIMALLOC_ARENA_ALL
-     endif()
- endif()
+@@ -217,8 +217,8 @@ if (ARM64 OR ARM OR X86 OR X64 OR X86_64)
+     # Its functionality in detecting x86 cpu features are lacking, so is support for Windows.
  
--onnxruntime_add_include_to_target(onnxruntime_common date_interface wil)
-+onnxruntime_add_include_to_target(onnxruntime_common date::date wil)
- target_include_directories(onnxruntime_common
-     PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS}
-     # propagate include directories of dependencies that are part of public interface
-     PUBLIC
-         ${OPTIONAL_LITE_INCLUDE_DIR})
- 
--target_link_libraries(onnxruntime_common safeint_interface Boost::mp11)
-+target_link_libraries(onnxruntime_common safeint_interface Boost::headers)
- 
- if(NOT WIN32)
-   target_include_directories(onnxruntime_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/external/nsync/public")
-diff --git a/cmake/onnxruntime_eager.cmake b/cmake/onnxruntime_eager.cmake
-index fbca8d6..aadeabe 100644
---- a/cmake/onnxruntime_eager.cmake
-+++ b/cmake/onnxruntime_eager.cmake
-@@ -10,7 +10,7 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_eager_srcs})
- 
- add_library(onnxruntime_eager ${onnxruntime_eager_srcs})
- install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/eager  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core)
--onnxruntime_add_include_to_target(onnxruntime_eager onnxruntime_common onnxruntime_framework onnxruntime_optimizer onnxruntime_graph onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_eager onnxruntime_common onnxruntime_framework onnxruntime_optimizer onnxruntime_graph onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- if(onnxruntime_ENABLE_INSTRUMENT)
-   target_compile_definitions(onnxruntime_eager PUBLIC ONNXRUNTIME_ENABLE_INSTRUMENT)
- endif()
-diff --git a/cmake/onnxruntime_flatbuffers.cmake b/cmake/onnxruntime_flatbuffers.cmake
-index bcb196b..49e10d8 100644
---- a/cmake/onnxruntime_flatbuffers.cmake
-+++ b/cmake/onnxruntime_flatbuffers.cmake
-@@ -9,7 +9,7 @@ file(GLOB onnxruntime_flatbuffers_srcs CONFIGURE_DEPENDS
- source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_flatbuffers_srcs})
- 
- onnxruntime_add_static_library(onnxruntime_flatbuffers ${onnxruntime_flatbuffers_srcs})
--onnxruntime_add_include_to_target(onnxruntime_flatbuffers onnx flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_flatbuffers onnx flatbuffers::flatbuffers)
- if(onnxruntime_ENABLE_INSTRUMENT)
-   target_compile_definitions(onnxruntime_flatbuffers PUBLIC ONNXRUNTIME_ENABLE_INSTRUMENT)
- endif()
-diff --git a/cmake/onnxruntime_framework.cmake b/cmake/onnxruntime_framework.cmake
-index dee3ff2..f518cd1 100644
---- a/cmake/onnxruntime_framework.cmake
-+++ b/cmake/onnxruntime_framework.cmake
-@@ -62,7 +62,7 @@ if (onnxruntime_ENABLE_TRAINING)
-   set(DLPACK_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external/dlpack/include)
-   target_include_directories(onnxruntime_framework PRIVATE ${DLPACK_INCLUDE_DIR})
- endif()
--onnxruntime_add_include_to_target(onnxruntime_framework onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_framework onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- set_target_properties(onnxruntime_framework PROPERTIES FOLDER "ONNXRuntime")
- # need onnx to build to create headers that this project includes
- add_dependencies(onnxruntime_framework ${onnxruntime_EXTERNAL_DEPENDENCIES})
-diff --git a/cmake/onnxruntime_graph.cmake b/cmake/onnxruntime_graph.cmake
-index 7c76f08..641761c 100644
---- a/cmake/onnxruntime_graph.cmake
-+++ b/cmake/onnxruntime_graph.cmake
-@@ -82,8 +82,8 @@ if (onnxruntime_ENABLE_TRAINING OR onnxruntime_ENABLE_TRAINING_OPS)
- endif()
- 
- onnxruntime_add_static_library(onnxruntime_graph ${onnxruntime_graph_lib_src})
--add_dependencies(onnxruntime_graph onnx_proto flatbuffers)
--onnxruntime_add_include_to_target(onnxruntime_graph onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+add_dependencies(onnxruntime_graph onnx_proto flatbuffers::flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_graph onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- if(NOT MSVC)
-   target_compile_options(onnxruntime_graph PRIVATE "-Wno-parentheses")
- endif()
-diff --git a/cmake/onnxruntime_language_interop_ops.cmake b/cmake/onnxruntime_language_interop_ops.cmake
-index a7cbe72..e4bf8db 100644
---- a/cmake/onnxruntime_language_interop_ops.cmake
-+++ b/cmake/onnxruntime_language_interop_ops.cmake
-@@ -4,5 +4,5 @@ include(onnxruntime_pyop.cmake)
- file (GLOB onnxruntime_language_interop_ops_src "${ONNXRUNTIME_ROOT}/core/language_interop_ops/language_interop_ops.cc")
- onnxruntime_add_static_library(onnxruntime_language_interop ${onnxruntime_language_interop_ops_src})
- add_dependencies(onnxruntime_language_interop onnxruntime_pyop)
--onnxruntime_add_include_to_target(onnxruntime_language_interop onnxruntime_common onnxruntime_graph onnxruntime_framework onnxruntime_pyop onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_language_interop onnxruntime_common onnxruntime_graph onnxruntime_framework onnxruntime_pyop onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- target_include_directories(onnxruntime_language_interop PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS})
-\ No newline at end of file
-diff --git a/cmake/onnxruntime_opschema_lib.cmake b/cmake/onnxruntime_opschema_lib.cmake
-index d3f6f89..9966339 100644
---- a/cmake/onnxruntime_opschema_lib.cmake
-+++ b/cmake/onnxruntime_opschema_lib.cmake
-@@ -27,10 +27,10 @@ target_compile_options(ort_opschema_lib PRIVATE -D_OPSCHEMA_LIB_=1)
- if(NOT MSVC)
-   target_compile_options(ort_opschema_lib PRIVATE "-Wno-parentheses")
- endif()
--set (OPSCHEMA_LIB_DEPENDENCIES onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+set (OPSCHEMA_LIB_DEPENDENCIES onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- 
- # ${CMAKE_CURRENT_BINARY_DIR} is so that #include "onnxruntime_config.h" is found
- target_include_directories(ort_opschema_lib PRIVATE ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${CMAKE_CURRENT_BINARY_DIR})
--onnxruntime_add_include_to_target(ort_opschema_lib onnxruntime_common onnx onnx_proto protobuf::libprotobuf flatbuffers)
-+onnxruntime_add_include_to_target(ort_opschema_lib onnxruntime_common onnx onnx_proto protobuf::libprotobuf flatbuffers::flatbuffers)
- add_dependencies(ort_opschema_lib ${OPSCHEMA_LIB_DEPENDENCIES})
- 
-diff --git a/cmake/onnxruntime_optimizer.cmake b/cmake/onnxruntime_optimizer.cmake
-index 96ca07e..ef1f24b 100644
---- a/cmake/onnxruntime_optimizer.cmake
-+++ b/cmake/onnxruntime_optimizer.cmake
-@@ -58,7 +58,7 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_optimizer_srcs})
- onnxruntime_add_static_library(onnxruntime_optimizer ${onnxruntime_optimizer_srcs})
- 
- install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/optimizer  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core)
--onnxruntime_add_include_to_target(onnxruntime_optimizer onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_optimizer onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- target_include_directories(onnxruntime_optimizer PRIVATE ${ONNXRUNTIME_ROOT})
- if (onnxruntime_ENABLE_TRAINING)
-   target_include_directories(onnxruntime_optimizer PRIVATE ${ORTTRAINING_ROOT})
-diff --git a/cmake/onnxruntime_providers.cmake b/cmake/onnxruntime_providers.cmake
-index 5b5ff58..0591216 100644
---- a/cmake/onnxruntime_providers.cmake
-+++ b/cmake/onnxruntime_providers.cmake
-@@ -183,7 +183,7 @@ if (MSVC)
-       target_compile_options(onnxruntime_providers PRIVATE "/wd4244")
-    endif()
- endif()
--onnxruntime_add_include_to_target(onnxruntime_providers onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_providers onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- 
- if (onnxruntime_BUILD_MS_EXPERIMENTAL_OPS)
-   target_compile_definitions(onnxruntime_providers PRIVATE BUILD_MS_EXPERIMENTAL_OPS=1)
-@@ -352,7 +352,7 @@ if (onnxruntime_USE_CUDA)
- 		target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
- 	  endif()
-   endif()
--  onnxruntime_add_include_to_target(onnxruntime_providers_cuda onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_cuda onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   if (onnxruntime_ENABLE_TRAINING OR onnxruntime_ENABLE_TRAINING_OPS)
-     onnxruntime_add_include_to_target(onnxruntime_providers_cuda onnxruntime_training)
-     target_link_libraries(onnxruntime_providers_cuda PRIVATE onnxruntime_training)
-@@ -448,7 +448,7 @@ if (onnxruntime_USE_DNNL)
-   add_dependencies(onnxruntime_providers_dnnl onnxruntime_providers_shared project_dnnl ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   target_include_directories(onnxruntime_providers_dnnl PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS} ${DNNL_INCLUDE_DIR} ${DNNL_OCL_INCLUDE_DIR})
-   # ${CMAKE_CURRENT_BINARY_DIR} is so that #include "onnxruntime_config.h" inside tensor_shape.h is found
--  target_link_libraries(onnxruntime_providers_dnnl PRIVATE dnnl ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11)
-+  target_link_libraries(onnxruntime_providers_dnnl PRIVATE dnnl ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::headers)
-   install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/dnnl  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers)
-   set_target_properties(onnxruntime_providers_dnnl PROPERTIES FOLDER "ONNXRuntime")
-   set_target_properties(onnxruntime_providers_dnnl PROPERTIES LINKER_LANGUAGE CXX)
-@@ -533,9 +533,9 @@ if (onnxruntime_USE_TENSORRT)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_tensorrt_cc_srcs})
-   onnxruntime_add_shared_library_module(onnxruntime_providers_tensorrt ${onnxruntime_providers_tensorrt_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_tensorrt onnxruntime_common onnx flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_tensorrt onnxruntime_common onnx flatbuffers::flatbuffers)
-   add_dependencies(onnxruntime_providers_tensorrt onnxruntime_providers_shared ${onnxruntime_EXTERNAL_DEPENDENCIES})
--  target_link_libraries(onnxruntime_providers_tensorrt PRIVATE ${onnxparser_link_libs} ${trt_link_libs} cudart ${ONNXRUNTIME_PROVIDERS_SHARED} ${PROTOBUF_LIB} flatbuffers)
-+  target_link_libraries(onnxruntime_providers_tensorrt PRIVATE ${onnxparser_link_libs} ${trt_link_libs} cudart ${ONNXRUNTIME_PROVIDERS_SHARED} ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   target_include_directories(onnxruntime_providers_tensorrt PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} ${onnxruntime_CUDNN_HOME}/include ${eigen_INCLUDE_DIRS} PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-   # ${CMAKE_CURRENT_BINARY_DIR} is so that #include "onnxruntime_config.h" inside tensor_shape.h is found
-   install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/tensorrt  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers)
-@@ -599,7 +599,7 @@ if (onnxruntime_USE_NUPHAR)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_nuphar_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_nuphar ${onnxruntime_providers_nuphar_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_nuphar onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_nuphar onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   set_target_properties(onnxruntime_providers_nuphar PROPERTIES FOLDER "ONNXRuntime")
-   target_include_directories(onnxruntime_providers_nuphar PRIVATE ${ONNXRUNTIME_ROOT} ${TVM_INCLUDES} ${eigen_INCLUDE_DIRS})
-   set_target_properties(onnxruntime_providers_nuphar PROPERTIES LINKER_LANGUAGE CXX)
-@@ -616,7 +616,7 @@ if (onnxruntime_USE_VITISAI)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_vitisai_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_vitisai ${onnxruntime_providers_vitisai_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_vitisai onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_vitisai onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   add_dependencies(onnxruntime_providers_vitisai ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   set_target_properties(onnxruntime_providers_vitisai PROPERTIES FOLDER "ONNXRuntime")
-   target_include_directories(onnxruntime_providers_vitisai PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS} ${VITISAI_INCLUDE_DIR})
-@@ -763,7 +763,7 @@ if (onnxruntime_USE_COREML)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_coreml_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_coreml ${onnxruntime_providers_coreml_cc_srcs} ${onnxruntime_providers_coreml_objcc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_coreml onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_coreml onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
-     onnxruntime_add_include_to_target(onnxruntime_providers_coreml onnxruntime_coreml_proto)
-     target_link_libraries(onnxruntime_providers_coreml PRIVATE onnxruntime_coreml_proto "-framework Foundation" "-framework CoreML")
-@@ -838,7 +838,7 @@ if (onnxruntime_USE_NNAPI_BUILTIN)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_nnapi_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_nnapi ${onnxruntime_providers_nnapi_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_nnapi onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf-lite flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_nnapi onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf-lite flatbuffers::flatbuffers)
-   target_link_libraries(onnxruntime_providers_nnapi)
-   add_dependencies(onnxruntime_providers_nnapi onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   set_target_properties(onnxruntime_providers_nnapi PROPERTIES CXX_STANDARD_REQUIRED ON)
-@@ -874,7 +874,7 @@ if (onnxruntime_USE_RKNPU)
-   )
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_rknpu_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_rknpu ${onnxruntime_providers_rknpu_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_rknpu onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf-lite flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_rknpu onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf-lite flatbuffers::flatbuffers)
-   target_link_libraries(onnxruntime_providers_rknpu PRIVATE -lrknpu_ddk)
-   add_dependencies(onnxruntime_providers_rknpu onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   set_target_properties(onnxruntime_providers_rknpu PROPERTIES FOLDER "ONNXRuntime")
-@@ -891,7 +891,7 @@ if (onnxruntime_USE_DML)
-   )
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_dml_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_dml ${onnxruntime_providers_dml_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_dml onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_dml onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   add_dependencies(onnxruntime_providers_dml ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   target_include_directories(onnxruntime_providers_dml PRIVATE ${ONNXRUNTIME_ROOT} ${ONNXRUNTIME_ROOT}/../cmake/external/wil/include)
- 
-@@ -960,7 +960,7 @@ if (onnxruntime_USE_MIGRAPHX)
-   set_target_properties(onnxruntime_providers_migraphx PROPERTIES FOLDER "ONNXRuntime")
-   target_compile_options(onnxruntime_providers_migraphx PRIVATE -Wno-error=sign-compare)
-   target_include_directories(onnxruntime_providers_migraphx PRIVATE ${ONNXRUNTIME_ROOT})
--  onnxruntime_add_include_to_target(onnxruntime_providers_migraphx onnxruntime_common onnxruntime_framework onnx flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_migraphx onnxruntime_common onnxruntime_framework onnx flatbuffers::flatbuffers)
-   add_dependencies(onnxruntime_providers_migraphx ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/migraphx  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers)
-   set_target_properties(onnxruntime_providers_migraphx PROPERTIES LINKER_LANGUAGE CXX)
-@@ -975,7 +975,7 @@ if (onnxruntime_USE_ACL)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_acl_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_acl ${onnxruntime_providers_acl_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_acl onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_acl onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   target_link_libraries(onnxruntime_providers_acl -L$ENV{LD_LIBRARY_PATH})
-   add_dependencies(onnxruntime_providers_acl ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   set_target_properties(onnxruntime_providers_acl PROPERTIES FOLDER "ONNXRuntime")
-@@ -993,7 +993,7 @@ if (onnxruntime_USE_ARMNN)
- 
-   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_armnn_cc_srcs})
-   onnxruntime_add_static_library(onnxruntime_providers_armnn ${onnxruntime_providers_armnn_cc_srcs})
--  onnxruntime_add_include_to_target(onnxruntime_providers_armnn onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_armnn onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   add_dependencies(onnxruntime_providers_armnn ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   set_target_properties(onnxruntime_providers_armnn PROPERTIES FOLDER "ONNXRuntime")
-   target_include_directories(onnxruntime_providers_armnn PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS} ${onnxruntime_ARMNN_HOME} ${onnxruntime_ARMNN_HOME}/include ${onnxruntime_ACL_HOME} ${onnxruntime_ACL_HOME}/include)
-@@ -1121,7 +1121,7 @@ if (onnxruntime_USE_ROCM)
+     if (CPUINFO_SUPPORTED)
+-      target_link_libraries(onnxruntime_common cpuinfo)
+-      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo clog)
++      target_link_libraries(onnxruntime_common cpuinfo::cpuinfo)
++      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo::cpuinfo cpuinfo::clog)
      endif()
    endif()
- 
--  onnxruntime_add_include_to_target(onnxruntime_providers_rocm onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_providers_rocm onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
-   add_dependencies(onnxruntime_providers_rocm ${onnxruntime_EXTERNAL_DEPENDENCIES})
-   install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/hip  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers)
-   set_target_properties(onnxruntime_providers_rocm PROPERTIES LINKER_LANGUAGE CXX)
-diff --git a/cmake/onnxruntime_pyop.cmake b/cmake/onnxruntime_pyop.cmake
-index 5f663cb..07e22bc 100644
---- a/cmake/onnxruntime_pyop.cmake
-+++ b/cmake/onnxruntime_pyop.cmake
-@@ -3,7 +3,7 @@
- file(GLOB onnxruntime_pyop_srcs "${ONNXRUNTIME_ROOT}/core/language_interop_ops/pyop/pyop.cc")
- onnxruntime_add_static_library(onnxruntime_pyop ${onnxruntime_pyop_srcs})
- add_dependencies(onnxruntime_pyop onnxruntime_graph)
--onnxruntime_add_include_to_target(onnxruntime_pyop onnxruntime_common onnxruntime_graph onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_pyop onnxruntime_common onnxruntime_graph onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- target_include_directories(onnxruntime_pyop PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS})
- onnxruntime_add_include_to_target(onnxruntime_pyop Python::Module Python::NumPy)
- if (TARGET Python::Python)
-diff --git a/cmake/onnxruntime_session.cmake b/cmake/onnxruntime_session.cmake
-index 7d87eaa..b92b153 100644
---- a/cmake/onnxruntime_session.cmake
-+++ b/cmake/onnxruntime_session.cmake
-@@ -19,7 +19,7 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_session_srcs})
- 
- onnxruntime_add_static_library(onnxruntime_session ${onnxruntime_session_srcs})
- install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/session  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core)
--onnxruntime_add_include_to_target(onnxruntime_session onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_session onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- if(onnxruntime_ENABLE_INSTRUMENT)
-   target_compile_definitions(onnxruntime_session PUBLIC ONNXRUNTIME_ENABLE_INSTRUMENT)
  endif()
-diff --git a/cmake/onnxruntime_training.cmake b/cmake/onnxruntime_training.cmake
-index 56b67c2..c78ff35 100644
---- a/cmake/onnxruntime_training.cmake
-+++ b/cmake/onnxruntime_training.cmake
-@@ -27,7 +27,7 @@ list(REMOVE_ITEM onnxruntime_training_srcs ${onnxruntime_training_framework_excu
- 
- onnxruntime_add_static_library(onnxruntime_training ${onnxruntime_training_srcs})
- add_dependencies(onnxruntime_training onnx tensorboard ${onnxruntime_EXTERNAL_DEPENDENCIES})
--onnxruntime_add_include_to_target(onnxruntime_training onnxruntime_common onnx onnx_proto tensorboard ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_training onnxruntime_common onnx onnx_proto tensorboard ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- 
- # fix event_writer.cc 4100 warning
- if(WIN32)
-@@ -74,7 +74,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
-     target_link_libraries(onnxruntime_training_runner PRIVATE Python::Python)
-   endif()
- 
--  onnxruntime_add_include_to_target(onnxruntime_training_runner onnxruntime_training onnxruntime_framework onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_training_runner onnxruntime_training onnxruntime_framework onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers::flatbuffers)
- 
-   target_include_directories(onnxruntime_training_runner PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${eigen_INCLUDE_DIRS} PUBLIC ${onnxruntime_graph_header})
-   target_link_libraries(onnxruntime_training_runner PRIVATE nlohmann_json::nlohmann_json)
-@@ -112,7 +112,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
-       "${ORTTRAINING_SOURCE_DIR}/models/mnist/main.cc"
-   )
-   onnxruntime_add_executable(onnxruntime_training_mnist ${training_mnist_src})
--  onnxruntime_add_include_to_target(onnxruntime_training_mnist onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_training_mnist onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers::flatbuffers)
-   target_include_directories(onnxruntime_training_mnist PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${eigen_INCLUDE_DIRS} ${CXXOPTS} ${extra_includes} ${onnxruntime_graph_header} ${onnxruntime_exec_src_dir} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx onnxruntime_training_runner)
- 
-   set(ONNXRUNTIME_LIBS
-@@ -157,7 +157,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
-       "${ORTTRAINING_SOURCE_DIR}/models/squeezenet/*.cc"
-   )
-   onnxruntime_add_executable(onnxruntime_training_squeezenet ${training_squeezene_src})
--  onnxruntime_add_include_to_target(onnxruntime_training_squeezenet onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_training_squeezenet onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers::flatbuffers)
-   target_include_directories(onnxruntime_training_squeezenet PUBLIC ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${eigen_INCLUDE_DIRS} ${extra_includes} ${onnxruntime_graph_header} ${onnxruntime_exec_src_dir} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx onnxruntime_training_runner)
- 
-   if(UNIX AND NOT APPLE)
-@@ -180,7 +180,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
-     endif()
-   endif()
- 
--  onnxruntime_add_include_to_target(onnxruntime_training_bert onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_training_bert onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers::flatbuffers)
-   target_include_directories(onnxruntime_training_bert PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${MPI_CXX_INCLUDE_DIRS} ${eigen_INCLUDE_DIRS} ${CXXOPTS} ${extra_includes} ${onnxruntime_graph_header} ${onnxruntime_exec_src_dir} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx onnxruntime_training_runner)
- 
-   target_link_libraries(onnxruntime_training_bert PRIVATE onnxruntime_training_runner onnxruntime_training ${ONNXRUNTIME_LIBS} ${onnxruntime_EXTERNAL_LIBRARIES})
-@@ -199,7 +199,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
-     endif()
-   endif()
- 
--  onnxruntime_add_include_to_target(onnxruntime_training_pipeline_poc onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_training_pipeline_poc onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers::flatbuffers)
-   target_include_directories(onnxruntime_training_pipeline_poc PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${MPI_CXX_INCLUDE_DIRS} ${eigen_INCLUDE_DIRS} ${CXXOPTS} ${extra_includes} ${onnxruntime_graph_header} ${onnxruntime_exec_src_dir} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx onnxruntime_training_runner)
-   if (onnxruntime_USE_NCCL)
-     target_include_directories(onnxruntime_training_pipeline_poc PRIVATE ${NCCL_INCLUDE_DIRS})
-@@ -220,7 +220,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
-     endif()
-   endif()
- 
--  onnxruntime_add_include_to_target(onnxruntime_training_gpt2 onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers)
-+  onnxruntime_add_include_to_target(onnxruntime_training_gpt2 onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} onnxruntime_training flatbuffers::flatbuffers)
-   target_include_directories(onnxruntime_training_gpt2 PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${MPI_CXX_INCLUDE_DIRS} ${eigen_INCLUDE_DIRS} ${CXXOPTS} ${extra_includes} ${onnxruntime_graph_header} ${onnxruntime_exec_src_dir} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx onnxruntime_training_runner)
- 
-   target_link_libraries(onnxruntime_training_gpt2 PRIVATE onnxruntime_training_runner onnxruntime_training ${ONNXRUNTIME_LIBS} ${onnxruntime_EXTERNAL_LIBRARIES})
-diff --git a/cmake/onnxruntime_unittests.cmake b/cmake/onnxruntime_unittests.cmake
-index 7cd6aac..f11e784 100644
---- a/cmake/onnxruntime_unittests.cmake
-+++ b/cmake/onnxruntime_unittests.cmake
-@@ -53,7 +53,7 @@ function(AddTest)
-   else()
-     target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock ${onnxruntime_EXTERNAL_LIBRARIES})
-   endif()
--  onnxruntime_add_include_to_target(${_UT_TARGET} date_interface flatbuffers)
-+  onnxruntime_add_include_to_target(${_UT_TARGET} date::date flatbuffers::flatbuffers)
-   target_include_directories(${_UT_TARGET} PRIVATE ${TEST_INC_DIR})
-   if (onnxruntime_USE_CUDA)
-     target_include_directories(${_UT_TARGET} PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${onnxruntime_CUDNN_HOME}/include)
-@@ -127,7 +127,7 @@ function(AddTest)
-     else()
-       target_link_libraries(${_UT_TARGET}_xc PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock ${onnxruntime_EXTERNAL_LIBRARIES})
-     endif()
--    onnxruntime_add_include_to_target(${_UT_TARGET}_xc date_interface flatbuffers)
-+    onnxruntime_add_include_to_target(${_UT_TARGET}_xc date::date flatbuffers::flatbuffers)
-     target_include_directories(${_UT_TARGET}_xc PRIVATE ${TEST_INC_DIR})
-     get_target_property(${_UT_TARGET}_DEFS ${_UT_TARGET} COMPILE_DEFINITIONS)
-     target_compile_definitions(${_UT_TARGET}_xc PRIVATE ${_UT_TARGET}_DEFS)
-@@ -577,7 +577,7 @@ endif()
- if (onnxruntime_USE_NCCL)
-   target_include_directories(onnxruntime_test_utils PRIVATE ${NCCL_INCLUDE_DIRS})
- endif()
--onnxruntime_add_include_to_target(onnxruntime_test_utils onnxruntime_common onnxruntime_framework onnxruntime_session GTest::gtest GTest::gmock onnx onnx_proto flatbuffers)
-+onnxruntime_add_include_to_target(onnxruntime_test_utils onnxruntime_common onnxruntime_framework onnxruntime_session GTest::gtest GTest::gmock onnx onnx_proto flatbuffers::flatbuffers)
- 
- 
- if (onnxruntime_USE_DML)
-@@ -609,7 +609,7 @@ if (MSVC AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-   target_compile_options(onnx_test_runner_common PRIVATE "/wd4244")
- endif()
- onnxruntime_add_include_to_target(onnx_test_runner_common onnxruntime_common onnxruntime_framework
--        onnxruntime_test_utils onnx onnx_proto re2::re2 flatbuffers)
-+        onnxruntime_test_utils onnx onnx_proto re2::re2 flatbuffers::flatbuffers)
- 
- add_dependencies(onnx_test_runner_common onnx_test_data_proto ${onnxruntime_EXTERNAL_DEPENDENCIES})
- target_include_directories(onnx_test_runner_common PRIVATE ${eigen_INCLUDE_DIRS} ${RE2_INCLUDE_DIR}
-diff --git a/cmake/winml.cmake b/cmake/winml.cmake
-index 4efc6fa..1beced0 100644
---- a/cmake/winml.cmake
-+++ b/cmake/winml.cmake
-@@ -319,7 +319,7 @@ set_target_properties(winml_adapter PROPERTIES CXX_STANDARD 17)
- set_target_properties(winml_adapter PROPERTIES CXX_STANDARD_REQUIRED ON)
- 
- # Compiler definitions
--onnxruntime_add_include_to_target(winml_adapter onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(winml_adapter onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- target_include_directories(winml_adapter PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS})
- add_dependencies(winml_adapter ${onnxruntime_EXTERNAL_DEPENDENCIES})
- 
-diff --git a/cmake/winml_unittests.cmake b/cmake/winml_unittests.cmake
-index e9ff2e5..8ffe1ab 100644
---- a/cmake/winml_unittests.cmake
-+++ b/cmake/winml_unittests.cmake
-@@ -270,7 +270,7 @@ target_include_directories(winml_test_adapter PRIVATE ${winml_lib_common_dir}/in
- target_include_directories(winml_test_adapter PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
- target_include_directories(winml_test_adapter PRIVATE ${ONNXRUNTIME_ROOT})
- 
--onnxruntime_add_include_to_target(winml_test_adapter onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
-+onnxruntime_add_include_to_target(winml_test_adapter onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- target_include_directories(winml_test_adapter PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS})
- add_dependencies(winml_test_adapter ${onnxruntime_EXTERNAL_DEPENDENCIES})
- target_include_directories(winml_test_adapter PRIVATE ${winml_adapter_dir})
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 377653e..7df5b67 100644
+index a2e8e93..c1dd8fc 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -20,6 +20,7 @@ project(onnxruntime C CXX)
+@@ -20,6 +20,7 @@ project(onnxruntime C CXX ASM)
  # Needed for Java
- set (CMAKE_C_STANDARD 99)
+ set(CMAKE_C_STANDARD 99)
  
 +include(GNUInstallDirs)
  include(CheckCXXCompilerFlag)
  include(CheckLanguage)
  include(CMakeDependentOption)
-@@ -836,9 +837,7 @@ set(ONNXRUNTIME_INCLUDE_DIR ${REPO_ROOT}/include/onnxruntime)
- # add_subdirectory(external/date EXCLUDE_FROM_ALL)
- find_package(date CONFIG REQUIRED) # date::date date::date-tz
- 
--set(SAFEINT_INCLUDE_DIR ${REPO_ROOT}/cmake/external/SafeInt)
--add_library(safeint_interface INTERFACE)
--target_include_directories(safeint_interface INTERFACE ${SAFEINT_INCLUDE_DIR})
-+find_path(SAFEINT_INCLUDE_DIR "SafeInt.hpp")
- 
- # set(OPTIONAL_LITE_INCLUDE_DIR ${REPO_ROOT}/cmake/external/optional-lite/include)
- find_package(optional-lite CONFIG REQUIRED)
-diff --git a/cmake/onnxruntime_common.cmake b/cmake/onnxruntime_common.cmake
-index bd33b34..08cf656 100644
---- a/cmake/onnxruntime_common.cmake
-+++ b/cmake/onnxruntime_common.cmake
-@@ -107,7 +107,8 @@ target_include_directories(onnxruntime_common
-     PUBLIC
-         ${OPTIONAL_LITE_INCLUDE_DIR})
- 
--target_link_libraries(onnxruntime_common safeint_interface Boost::headers)
-+target_include_directories(onnxruntime_common PUBLIC ${SAFEINT_INCLUDE_DIR})
-+target_link_libraries(onnxruntime_common Boost::headers)
- 
- if(NOT WIN32)
-   target_include_directories(onnxruntime_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/external/nsync/public")
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 7df5b67..6e00339 100644
+index c1dd8fc..1db7687 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -1795,7 +1795,8 @@ if(WIN32)
-   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${SYS_PATH_LIB} Shlwapi)
+@@ -744,9 +744,9 @@ endif()
+ 
+ if (NOT WIN32)
+   if (onnxruntime_PREFER_SYSTEM_LIB)
+-    find_package(nsync)
++    find_package(unofficial-nsync CONFIG REQUIRED) # unofficial::nsync::nsync_cpp
+   endif()
+-  if (TARGET nsync_cpp)  # linking error with nsync_FOUND (why?)
++  if (TARGET unofficial::nsync::nsync_cpp)  # linking error with nsync_FOUND (why?)
+     message("Use nsync from preinstalled system lib")
+   else()
+     message("Use nsync from submodule")
+@@ -2021,7 +2021,7 @@ if (WIN32)
+   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${SYS_PATH_LIB})
    list(APPEND onnxruntime_EXTERNAL_LIBRARIES debug Dbghelp)
  else()
 -  list(APPEND onnxruntime_EXTERNAL_LIBRARIES nsync_cpp)
-+  find_library(NSYNC_CPP_LIBPATH NAMES nsync_cpp)
-+  list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${NSYNC_CPP_LIBPATH})
++  list(APPEND onnxruntime_EXTERNAL_LIBRARIES unofficial::nsync::nsync_cpp)
    list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${CMAKE_DL_LIBS} Threads::Threads)
  endif()
  
-diff --git a/cmake/onnxruntime_common.cmake b/cmake/onnxruntime_common.cmake
-index 08cf656..e0e11bc 100644
---- a/cmake/onnxruntime_common.cmake
-+++ b/cmake/onnxruntime_common.cmake
-@@ -214,7 +214,7 @@ if (ARM64 OR ARM OR X86 OR X64 OR X86_64)
-     # Its functionality in detecting x86 cpu features are lacking, so is support for Windows.
- 
-     target_include_directories(onnxruntime_common PRIVATE ${PYTORCH_CPUINFO_INCLUDE_DIR})
--    target_link_libraries(onnxruntime_common cpuinfo)
--    list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo clog)
-+    target_link_libraries(onnxruntime_common cpuinfo::cpuinfo)
-+    list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo::clog cpuinfo::cpuinfo)
-   endif()
- endif()
 diff --git a/cmake/onnxruntime_providers.cmake b/cmake/onnxruntime_providers.cmake
-index 0591216..c271c94 100644
+index 77eac4b..b2b94a8 100644
 --- a/cmake/onnxruntime_providers.cmake
 +++ b/cmake/onnxruntime_providers.cmake
-@@ -416,10 +416,10 @@ if (onnxruntime_USE_CUDA)
+@@ -521,10 +521,10 @@ if (onnxruntime_USE_CUDA)
  
    if(APPLE)
      set_property(TARGET onnxruntime_providers_cuda APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/core/providers/cuda/exported_symbols.lst")
 -    target_link_libraries(onnxruntime_providers_cuda PRIVATE nsync_cpp)
-+    target_link_libraries(onnxruntime_providers_cuda PRIVATE ${NSYNC_CPP_LIBPATH})
++    target_link_libraries(onnxruntime_providers_cuda PRIVATE unofficial::nsync::nsync_cpp)
    elseif(UNIX)
      set_property(TARGET onnxruntime_providers_cuda APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/cuda/version_script.lds -Xlinker --gc-sections")
 -    target_link_libraries(onnxruntime_providers_cuda PRIVATE nsync_cpp)
-+    target_link_libraries(onnxruntime_providers_cuda PRIVATE ${NSYNC_CPP_LIBPATH})
++    target_link_libraries(onnxruntime_providers_cuda PRIVATE unofficial::nsync::nsync_cpp)
    elseif(WIN32)
      set_property(TARGET onnxruntime_providers_cuda APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/cuda/symbols.def")
    else()
-@@ -464,10 +464,10 @@ if (onnxruntime_USE_DNNL)
+@@ -577,10 +577,10 @@ if (onnxruntime_USE_DNNL)
        INSTALL_RPATH "@loader_path"
        BUILD_WITH_INSTALL_RPATH TRUE
        INSTALL_RPATH_USE_LINK_PATH FALSE)
 -    target_link_libraries(onnxruntime_providers_dnnl PRIVATE nsync_cpp)
-+    target_link_libraries(onnxruntime_providers_dnnl PRIVATE ${NSYNC_CPP_LIBPATH})
++    target_link_libraries(onnxruntime_providers_dnnl PRIVATE unofficial::nsync::nsync_cpp)
    elseif(UNIX)
      set_property(TARGET onnxruntime_providers_dnnl APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/dnnl/version_script.lds -Xlinker --gc-sections -Xlinker -rpath=\$ORIGIN")
 -    target_link_libraries(onnxruntime_providers_dnnl PRIVATE nsync_cpp)
-+    target_link_libraries(onnxruntime_providers_dnnl PRIVATE ${NSYNC_CPP_LIBPATH})
++    target_link_libraries(onnxruntime_providers_dnnl PRIVATE unofficial::nsync::nsync_cpp)
    elseif(WIN32)
      set_property(TARGET onnxruntime_providers_dnnl APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/dnnl/symbols.def")
    else()
-@@ -554,11 +554,11 @@ if (onnxruntime_USE_TENSORRT)
+@@ -673,11 +673,11 @@ if (onnxruntime_USE_TENSORRT)
  
    if(APPLE)
      set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/core/providers/tensorrt/exported_symbols.lst")
 -    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE nsync_cpp)
-+    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE ${NSYNC_CPP_LIBPATH})
++    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE unofficial::nsync::nsync_cpp)
    elseif(UNIX)
      set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-deprecated-declarations")
      set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/tensorrt/version_script.lds -Xlinker --gc-sections")
 -    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE nsync_cpp stdc++fs)
-+    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE ${NSYNC_CPP_LIBPATH} stdc++fs)
++    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE unofficial::nsync::nsync_cpp stdc++fs)
    elseif(WIN32)
      set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/tensorrt/symbols.def")
    else()
-diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 6e00339..0106222 100644
---- a/cmake/CMakeLists.txt
-+++ b/cmake/CMakeLists.txt
-@@ -1211,7 +1211,7 @@ function(onnxruntime_add_shared_library target_name)
- endfunction()
+@@ -1217,7 +1217,7 @@ if (onnxruntime_USE_MIGRAPHX)
+   target_compile_options(onnxruntime_providers_migraphx PRIVATE -Wno-error=sign-compare)
+   set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-deprecated-declarations")
+   set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/migraphx/version_script.lds -Xlinker --gc-sections")
+-  target_link_libraries(onnxruntime_providers_migraphx PRIVATE nsync_cpp stdc++fs)
++  target_link_libraries(onnxruntime_providers_migraphx PRIVATE unofficial::nsync::nsync_cpp stdc++fs)
  
- function(onnxruntime_add_static_library target_name)
--  add_library(${target_name} ${ARGN})
-+  add_library(${target_name} STATIC ${ARGN})
-   onnxruntime_configure_target(${target_name})
- endfunction()
+   install(TARGETS onnxruntime_providers_migraphx
+           ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -1445,7 +1445,7 @@ if (onnxruntime_USE_ROCM)
  
-diff --git a/cmake/onnxruntime_graph.cmake b/cmake/onnxruntime_graph.cmake
-index 641761c..91e2871 100644
---- a/cmake/onnxruntime_graph.cmake
-+++ b/cmake/onnxruntime_graph.cmake
-@@ -82,7 +82,7 @@ if (onnxruntime_ENABLE_TRAINING OR onnxruntime_ENABLE_TRAINING_OPS)
- endif()
- 
- onnxruntime_add_static_library(onnxruntime_graph ${onnxruntime_graph_lib_src})
--add_dependencies(onnxruntime_graph onnx_proto flatbuffers::flatbuffers)
-+target_link_libraries(onnxruntime_graph PRIVATE onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- onnxruntime_add_include_to_target(onnxruntime_graph onnxruntime_common onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers)
- if(NOT MSVC)
-   target_compile_options(onnxruntime_graph PRIVATE "-Wno-parentheses")
-diff --git a/cmake/onnxruntime_opschema_lib.cmake b/cmake/onnxruntime_opschema_lib.cmake
-index 9966339..b135ef0 100644
---- a/cmake/onnxruntime_opschema_lib.cmake
-+++ b/cmake/onnxruntime_opschema_lib.cmake
-@@ -32,5 +32,5 @@ set (OPSCHEMA_LIB_DEPENDENCIES onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flat
- # ${CMAKE_CURRENT_BINARY_DIR} is so that #include "onnxruntime_config.h" is found
- target_include_directories(ort_opschema_lib PRIVATE ${ONNXRUNTIME_ROOT} ${ORTTRAINING_ROOT} ${CMAKE_CURRENT_BINARY_DIR})
- onnxruntime_add_include_to_target(ort_opschema_lib onnxruntime_common onnx onnx_proto protobuf::libprotobuf flatbuffers::flatbuffers)
--add_dependencies(ort_opschema_lib ${OPSCHEMA_LIB_DEPENDENCIES})
-+target_link_libraries(ort_opschema_lib PRIVATE ${OPSCHEMA_LIB_DEPENDENCIES})
- 
+   if(UNIX)
+     set_property(TARGET onnxruntime_providers_rocm APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/rocm/version_script.lds -Xlinker --gc-sections")
+-    target_link_libraries(onnxruntime_providers_rocm PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_rocm PRIVATE unofficial::nsync::nsync_cpp)
+   else()
+     message(FATAL_ERROR "onnxruntime_providers_rocm unknown platform, need to specify shared library exports for it")
+   endif()

--- a/ports/onnxruntime/fix-sources.patch
+++ b/ports/onnxruntime/fix-sources.patch
@@ -11,3 +11,143 @@ index 263e936..3ee70f3 100644
  #if defined(__GNUC__)
  #pragma GCC diagnostic pop
  #endif
+diff --git a/onnxruntime/core/flatbuffers/flatbuffers_utils.cc b/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
+index 8382c42..dedee5f 100644
+--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
++++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
+@@ -35,9 +35,9 @@ static flatbuffers::Offset<fbs::Dimension> SaveTensorDimensionOrtFormat(
+   auto denotation = SaveStringToOrtFormat(builder, tensor_shape_dim.has_denotation(), tensor_shape_dim.denotation());
+   flatbuffers::Offset<fbs::DimensionValue> dim_val;
+   if (tensor_shape_dim.has_dim_param()) {
+-    dim_val = fbs::CreateDimensionValueDirect(builder, fbs::DimensionValueType::PARAM, 0, tensor_shape_dim.dim_param().c_str());
++    dim_val = fbs::CreateDimensionValueDirect(builder, fbs::DimensionValueType::DimensionValueType_PARAM, 0, tensor_shape_dim.dim_param().c_str());
+   } else if (tensor_shape_dim.has_dim_value()) {
+-    dim_val = fbs::CreateDimensionValueDirect(builder, fbs::DimensionValueType::VALUE, tensor_shape_dim.dim_value());
++    dim_val = fbs::CreateDimensionValueDirect(builder, fbs::DimensionValueType::DimensionValueType_VALUE, tensor_shape_dim.dim_value());
+   } else {
+     dim_val = fbs::CreateDimensionValueDirect(builder);
+   }
+@@ -96,7 +96,7 @@ static Status SaveTypeInfoOrtFormat(flatbuffers::FlatBufferBuilder& builder,
+                                     const TypeProto& type_proto,
+                                     flatbuffers::Offset<fbs::TypeInfo>& fbs_type_info) {
+   auto denotation = SaveStringToOrtFormat(builder, type_proto.has_denotation(), type_proto.denotation());
+-  auto value_type = fbs::TypeInfoValue::tensor_type;
++  auto value_type = fbs::TypeInfoValue_tensor_type;
+   flatbuffers::Offset<void> value;
+   auto value_case = type_proto.value_case();
+   switch (value_case) {
+@@ -107,14 +107,14 @@ static Status SaveTypeInfoOrtFormat(flatbuffers::FlatBufferBuilder& builder,
+       value = fbs_tensor_type.Union();
+     } break;
+     case TypeProto::kSequenceType: {
+-      value_type = fbs::TypeInfoValue::sequence_type;
++      value_type = fbs::TypeInfoValue_sequence_type;
+       flatbuffers::Offset<fbs::SequenceType> fbs_sequence_type;
+       ORT_RETURN_IF_ERROR(
+           SaveSequenceTypeOrtFormat(builder, type_proto.sequence_type(), fbs_sequence_type));
+       value = fbs_sequence_type.Union();
+     } break;
+     case TypeProto::kMapType: {
+-      value_type = fbs::TypeInfoValue::map_type;
++      value_type = fbs::TypeInfoValue_map_type;
+       flatbuffers::Offset<fbs::MapType> fbs_map_type;
+       ORT_RETURN_IF_ERROR(
+           SaveMapTypeOrtFormat(builder, type_proto.map_type(), fbs_map_type));
+@@ -176,9 +176,9 @@ static Status LoadTensorDimensionOrtFormat(const fbs::Dimension& fbs_dim,
+   auto fbs_dim_val = fbs_dim.value();
+   if (fbs_dim_val) {
+     auto type = fbs_dim_val->dim_type();
+-    if (type == fbs::DimensionValueType::VALUE)
++    if (type == fbs::DimensionValueType::DimensionValueType_VALUE)
+       dim.set_dim_value(fbs_dim_val->dim_value());
+-    else if (type == fbs::DimensionValueType::PARAM) {
++    else if (type == fbs::DimensionValueType::DimensionValueType_PARAM) {
+       auto fbs_dim_param = fbs_dim_val->dim_param();
+       ORT_RETURN_IF(nullptr == fbs_dim_param, "dim_param value with no name. Invalid ORT format model.");
+       dim.set_dim_param(fbs_dim_param->str());
+@@ -237,15 +237,15 @@ static Status LoadTypeInfoOrtFormat(const fbs::TypeInfo& fbs_type_info,
+                                     TypeProto& type_proto) {
+   LOAD_STR_FROM_ORT_FORMAT(type_proto, denotation, fbs_type_info.denotation());
+   auto value_type = fbs_type_info.value_type();
+-  if (value_type == fbs::TypeInfoValue::tensor_type) {
++  if (value_type == fbs::TypeInfoValue_tensor_type) {
+     auto fbs_tensor_type = fbs_type_info.value_as_tensor_type();
+     ORT_RETURN_IF(nullptr == fbs_tensor_type, "Null tensor type info. Invalid ORT format model.");
+     ORT_RETURN_IF_ERROR(LoadTensorTypeAndShapeOrtFormat(*fbs_tensor_type, *type_proto.mutable_tensor_type()));
+-  } else if (value_type == fbs::TypeInfoValue::sequence_type) {
++  } else if (value_type == fbs::TypeInfoValue_sequence_type) {
+     auto fbs_sequence_type = fbs_type_info.value_as_sequence_type();
+     ORT_RETURN_IF(nullptr == fbs_sequence_type, "Null sequence type info. Invalid ORT format model.");
+     ORT_RETURN_IF_ERROR(LoadSequenceTypeOrtFormat(*fbs_sequence_type, *type_proto.mutable_sequence_type()));
+-  } else if (value_type == fbs::TypeInfoValue::map_type) {
++  } else if (value_type == fbs::TypeInfoValue_map_type) {
+     auto fbs_map_type = fbs_type_info.value_as_map_type();
+     ORT_RETURN_IF(nullptr == fbs_map_type, "Null map type info. Invalid ORT format model.");
+     ORT_RETURN_IF_ERROR(LoadMapTypeOrtFormat(*fbs_map_type, *type_proto.mutable_map_type()));
+diff --git a/onnxruntime/core/graph/graph_flatbuffers_utils.cc b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+index d89bae6..225ef33 100644
+--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
++++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+@@ -108,44 +108,44 @@ Status SaveAttributeOrtFormat(flatbuffers::FlatBufferBuilder& builder,
+   auto doc_string = SaveStringToOrtFormat(builder, attr_proto.has_doc_string(), attr_proto.doc_string());
+   auto type = static_cast<fbs::AttributeType>(attr_proto.type());
+   switch (type) {
+-    case fbs::AttributeType::FLOAT: {
++    case fbs::AttributeType::AttributeType_FLOAT: {
+       GET_FBS_ATTR(builder, type, f, attr_proto.f());
+     } break;
+-    case fbs::AttributeType::INT: {
++    case fbs::AttributeType::AttributeType_INT: {
+       GET_FBS_ATTR(builder, type, i, attr_proto.i());
+     } break;
+-    case fbs::AttributeType::STRING: {
++    case fbs::AttributeType::AttributeType_STRING: {
+       auto s = builder.CreateString(attr_proto.s());
+       GET_FBS_ATTR(builder, type, s, s);
+     } break;
+-    case fbs::AttributeType::TENSOR: {
++    case fbs::AttributeType::AttributeType_TENSOR: {
+       flatbuffers::Offset<fbs::Tensor> fbs_tensor;
+       ORT_RETURN_IF_ERROR(
+           SaveInitializerOrtFormat(builder, attr_proto.t(), model_path, fbs_tensor));
+       GET_FBS_ATTR(builder, type, t, fbs_tensor);
+     } break;
+-    case fbs::AttributeType::GRAPH: {
++    case fbs::AttributeType::AttributeType_GRAPH: {
+       ORT_RETURN_IF(nullptr == subgraph, "Graph attribute value was null. Invalid ORT format model.");
+       flatbuffers::Offset<fbs::Graph> fbs_graph;
+       ORT_RETURN_IF_ERROR(subgraph->SaveToOrtFormat(builder, fbs_graph));
+       GET_FBS_ATTR(builder, type, g, fbs_graph);
+     } break;
+-    case fbs::AttributeType::FLOATS: {
++    case fbs::AttributeType::AttributeType_FLOATS: {
+       GET_DATA_VEC(float, floats_vec_, attr_proto.floats());
+       auto floats = builder.CreateVector(floats_vec_);
+       GET_FBS_ATTR(builder, type, floats, floats);
+     } break;
+-    case fbs::AttributeType::INTS: {
++    case fbs::AttributeType::AttributeType_INTS: {
+       GET_DATA_VEC(int64_t, ints_vec_, attr_proto.ints());
+       auto ints = builder.CreateVector(ints_vec_);
+       GET_FBS_ATTR(builder, type, ints, ints);
+     } break;
+-    case fbs::AttributeType::STRINGS: {
++    case fbs::AttributeType::AttributeType_STRINGS: {
+       GET_DATA_VEC(std::string, strings_vec_, attr_proto.strings());
+       auto strings = builder.CreateVectorOfStrings(strings_vec_);
+       GET_FBS_ATTR(builder, type, strings, strings);
+     } break;
+-    case fbs::AttributeType::TENSORS: {
++    case fbs::AttributeType::AttributeType_TENSORS: {
+       std::vector<flatbuffers::Offset<fbs::Tensor>> fbs_tensors_vec;
+       fbs_tensors_vec.reserve(attr_proto.tensors().size());
+       for (const auto& tensor : attr_proto.tensors()) {
+@@ -184,7 +184,7 @@ Status LoadInitializerOrtFormat(const fbs::Tensor& fbs_tensor,
+ 
+   auto fbs_data_type = fbs_tensor.data_type();
+   initializer.set_data_type(static_cast<int32_t>(fbs_data_type));
+-  if (fbs_data_type == fbs::TensorDataType::STRING) {
++  if (fbs_data_type == fbs::TensorDataType::TensorDataType_STRING) {
+     auto fbs_str_data = fbs_tensor.string_data();
+     ORT_RETURN_IF(nullptr == fbs_str_data, "Missing string data for initializer. Invalid ORT format model.");
+     auto mutable_str_data = initializer.mutable_string_data();

--- a/ports/onnxruntime/fix-sources.patch
+++ b/ports/onnxruntime/fix-sources.patch
@@ -1,18 +1,5 @@
-diff --git a/objectivec/src/ort_value.mm b/objectivec/src/ort_value.mm
-index f55659d..b48e7f1 100644
---- a/objectivec/src/ort_value.mm
-+++ b/objectivec/src/ort_value.mm
-@@ -5,7 +5,7 @@
- 
- #include <optional>
- 
--#include "safeint/SafeInt.hpp"
-+#include <SafeInt.hpp>
- 
- #include "onnxruntime_cxx_api.h"
- 
 diff --git a/onnxruntime/core/common/safeint.h b/onnxruntime/core/common/safeint.h
-index 263e936..82bbe83 100644
+index 263e936..3ee70f3 100644
 --- a/onnxruntime/core/common/safeint.h
 +++ b/onnxruntime/core/common/safeint.h
 @@ -32,7 +32,7 @@ class SafeIntExceptionHandler<onnxruntime::OnnxRuntimeException> {
@@ -20,7 +7,7 @@ index 263e936..82bbe83 100644
  #endif
  #endif
 -#include "safeint/SafeInt.hpp"
-+#include <SafeInt.hpp>
++#include "SafeInt.hpp"
  #if defined(__GNUC__)
  #pragma GCC diagnostic pop
  #endif

--- a/ports/onnxruntime/fix-sources.patch
+++ b/ports/onnxruntime/fix-sources.patch
@@ -151,3 +151,37 @@ index d89bae6..225ef33 100644
      auto fbs_str_data = fbs_tensor.string_data();
      ORT_RETURN_IF(nullptr == fbs_str_data, "Missing string data for initializer. Invalid ORT format model.");
      auto mutable_str_data = initializer.mutable_string_data();
+diff --git a/onnxruntime/core/framework/session_options.h b/onnxruntime/core/framework/session_options.h
+index c301229..50e5e63 100644
+--- a/onnxruntime/core/framework/session_options.h
++++ b/onnxruntime/core/framework/session_options.h
+@@ -11,6 +11,7 @@
+ #include "core/optimizer/graph_transformer_level.h"
+ #include "core/util/thread_utils.h"
+ #include "core/framework/config_options.h"
++#include "core/framework/ort_value.h"
+ 
+ namespace onnxruntime {
+ 
+diff --git a/onnxruntime/core/providers/xnnpack/nn/conv.cc b/onnxruntime/core/providers/xnnpack/nn/conv.cc
+index d9f6134..8003d10 100644
+--- a/onnxruntime/core/providers/xnnpack/nn/conv.cc
++++ b/onnxruntime/core/providers/xnnpack/nn/conv.cc
+@@ -60,7 +60,7 @@ Status CreateXnnpackKernel(const ConvAttributes& conv_attrs,
+         gsl::narrow<uint32_t>(conv_attrs.group), 1, group_output_channels,
+         C, M,  // input channel stride, output channel stride
+         W_data, B_data,
+-        output_min, output_max, flags, &p);
++        output_min, output_max, flags, xnn_caches_t{}, &p);
+ 
+   } else {
+     status = xnn_create_convolution2d_nhwc_f32(
+@@ -71,7 +71,7 @@ Status CreateXnnpackKernel(const ConvAttributes& conv_attrs,
+         gsl::narrow<uint32_t>(conv_attrs.group), C, M,  // groups, group_input_channels, group_output_channels
+         C, M,                                           // input channel stride, output channel stride
+         W_data, B_data,
+-        output_min, output_max, flags, &p);
++        output_min, output_max, flags, xnn_caches_t{}, &p);
+   }
+ 
+   if (status != xnn_status_success) {

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -1,17 +1,12 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
-if("training" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_LINUX)
-        message(WARNING "This feature requires 'libopenmpi-dev' package")
-    endif()
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/onnxruntime
-    REF v1.9.1
-    SHA512 66c4bff4c4f633885ba7d0601337d0f16c0eeef7e3c1f492f2d21f27f06f748260e28105083b5defbebf624f4f26dc59355de7e3e0ef81c6c27b01b936a98ce9
-    HEAD_REF master
+    REF v1.12.1
+    SHA512 fc2e8be54fbeb32744c8882e61aa514be621eb621a073d05a85c6e2deac8c9bf1103e746711f5c33a4fa55a257807ba0159d9f23684f4926ff38b40591575d91
     PATCHES
         fix-cmake.patch
         fix-sources.patch
@@ -24,28 +19,64 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         cuda     onnxruntime_USE_CUDA
         cuda     onnxruntime_USE_NCCL
         tensorrt onnxruntime_USE_TENSORRT
+        tensorrt onnxruntime_TENSORRT_PLACEHOLDER_BUILDER
+        directml onnxruntime_USE_DML
+        winml    onnxruntime_USE_WINML
+        mimalloc onnxruntime_USE_MIMALLOC
+        valgrind onnxruntime_USE_VALGRIND
+        xnnpack  onnxruntime_USE_XNNPACK
+    INVERTED_FEATURES
+        abseil onnxruntime_DISABLE_ABSEIL
+
 )
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    # target platform should be informed to activate SIMD properly
+    if(TARGET_TRIPLET MATCHES [Xx]64)
+        list(APPEND PLATFORM_OPTIONS -DCMAKE_GENERATOR_PLATFORM="x64")
+    elseif(TARGET_TRIPLET MATCHES [Xx]86)
+        list(APPEND PLATFORM_OPTIONS -DCMAKE_GENERATOR_PLATFORM="Win32")
+    endif()
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+vcpkg_find_acquire_program(PYTHON3)
+message(STATUS "Using Python3: ${PYTHON3}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/cmake"
+    WINDOWS_USE_MSBUILD
+    GENERATOR Ninja
     OPTIONS
         ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+        -DPython_EXECUTABLE="${PYTHON3}"
+        # -DProtobuf_USE_STATIC_LIBS=OFF
         -DBUILD_PKGCONFIG_FILES=ON
-        -Donnxruntime_BUILD_SHARED_LIB=ON
+        -Donnxruntime_BUILD_SHARED_LIB=${BUILD_SHARED}
         -Donnxruntime_BUILD_UNIT_TESTS=OFF
+        -Donnxruntime_CROSS_COMPILING=${VCPKG_CROSSCOMPILING}
+        -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=${VCPKG_TARGET_IS_WINDOWS}
         -Donnxruntime_PREFER_SYSTEM_LIB=ON
         -Donnxruntime_USE_FULL_PROTOBUF=ON
-        -Donnxruntime_USE_PREINSTALLED_EIGEN=ON
+        -Donnxruntime_USE_PREINSTALLED_EIGEN=ON -Deigen_SOURCE_PATH="${CURRENT_INSTALLED_DIR}/include"
         -Donnxruntime_USE_EXTENSIONS=OFF
         -Donnxruntime_USE_MPI=${VCPKG_TARGET_IS_LINUX}
+        -Donnxruntime_ENABLE_BITCODE=${VCPKG_TARGET_IS_IOS}
         -Donnxruntime_ENABLE_PYTHON=OFF
         -Donnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS=OFF
     OPTIONS_DEBUG
         -Donnxruntime_ENABLE_MEMLEAK_CHECKER=OFF
         -Donnxruntime_ENABLE_MEMORY_PROFILE=OFF
+        -Donnxruntime_ENABLE_CUDA_PROFILING=ON
         -Donnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=ON
 )
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_cmake_build(TARGET onnxruntime)
+endif()
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig() # pkg_check_modules(libonnxruntime)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -1,4 +1,4 @@
-if(VCPKG_TARGET_IS_WINDOWS)
+if(NOT VCPKG_TARGET_IS_IOS)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
@@ -22,6 +22,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tensorrt onnxruntime_TENSORRT_PLACEHOLDER_BUILDER
         directml onnxruntime_USE_DML
         winml    onnxruntime_USE_WINML
+        coreml   onnxruntime_USE_COREML
         mimalloc onnxruntime_USE_MIMALLOC
         valgrind onnxruntime_USE_VALGRIND
         xnnpack  onnxruntime_USE_XNNPACK
@@ -55,6 +56,7 @@ vcpkg_cmake_configure(
         # -DProtobuf_USE_STATIC_LIBS=OFF
         -DBUILD_PKGCONFIG_FILES=ON
         -Donnxruntime_BUILD_SHARED_LIB=${BUILD_SHARED}
+        -Donnxruntime_BUILD_APPLE_FRAMEWORK=${VCPKG_TARGET_IS_IOS}
         -Donnxruntime_BUILD_UNIT_TESTS=OFF
         -Donnxruntime_CROSS_COMPILING=${VCPKG_CROSSCOMPILING}
         -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=${VCPKG_TARGET_IS_WINDOWS}
@@ -72,9 +74,7 @@ vcpkg_cmake_configure(
         -Donnxruntime_ENABLE_CUDA_PROFILING=ON
         -Donnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=ON
 )
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_build(TARGET onnxruntime)
-endif()
+vcpkg_cmake_build(TARGET onnxruntime)
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig() # pkg_check_modules(libonnxruntime)

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -27,6 +27,12 @@ file(RENAME "${SOURCE_PATH}/onnxruntime/core/flatbuffers/schema/ort_generated.h"
             "${SOURCE_PATH}/onnxruntime/core/flatbuffers/schema/ort.fbs.h"
 )
 
+if("xnnpack" IN_LIST FEATURES)
+    # see https://github.com/microsoft/onnxruntime/pull/11798
+    file(MAKE_DIRECTORY "${SOURCE_PATH}/include/onnxruntime/core/providers/xnnpack")
+    file(WRITE "${SOURCE_PATH}/include/onnxruntime/core/providers/xnnpack/xnnpack_provider_factory.h" "#pragma once")
+endif()
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         training  onnxruntime_ENABLE_TRAINING
@@ -91,7 +97,7 @@ vcpkg_cmake_configure(
         -Donnxruntime_USE_FULL_PROTOBUF=ON
         -Donnxruntime_USE_PREINSTALLED_EIGEN=ON -Deigen_SOURCE_PATH="${CURRENT_INSTALLED_DIR}/include"
         -Donnxruntime_USE_EXTENSIONS=OFF
-        -Donnxruntime_USE_MPI=${VCPKG_TARGET_IS_LINUX}
+        -Donnxruntime_USE_MPI=OFF # ${VCPKG_TARGET_IS_LINUX}
         -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=${VCPKG_TARGET_IS_WINDOWS}
         -Donnxruntime_ENABLE_BITCODE=${VCPKG_TARGET_IS_IOS}
         -Donnxruntime_ENABLE_PYTHON=OFF

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -44,6 +44,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
     else()
         message(FATAL_ERROR "Unexpected architecture: ${VCPKG_TARGET_ARCHITECTURE}")
     endif()
+    list(APPEND GENERATOR_OPTIONS WINDOWS_USE_MSBUILD)
+else()
+    list(APPEND GENERATOR_OPTIONS GENERATOR Ninja)
 endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
@@ -53,8 +56,7 @@ message(STATUS "Using Python3: ${PYTHON3}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/cmake"
-    WINDOWS_USE_MSBUILD
-    GENERATOR Ninja
+    ${GENERATOR_OPTIONS}
     OPTIONS
         ${FEATURE_OPTIONS}
         ${PLATFORM_OPTIONS}

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -12,22 +12,39 @@ vcpkg_from_github(
         fix-sources.patch
 )
 
+find_program(FLATC_EXECUTABLE NAMES flatc
+    PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/flatbuffers"
+    REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH
+)
+message(STATUS "Using flatc: ${FLATC_EXECUTABLE}")
+
+vcpkg_execute_required_process(
+    COMMAND ${FLATC_EXECUTABLE} --cpp ort.fbs
+    LOGNAME codegen-flatc-cpp
+    WORKING_DIRECTORY "${SOURCE_PATH}/onnxruntime/core/flatbuffers/schema/"
+)
+file(RENAME "${SOURCE_PATH}/onnxruntime/core/flatbuffers/schema/ort_generated.h"
+            "${SOURCE_PATH}/onnxruntime/core/flatbuffers/schema/ort.fbs.h"
+)
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        training onnxruntime_ENABLE_TRAINING
-        training onnxruntime_ENABLE_TRAINING_OPS
-        cuda     onnxruntime_USE_CUDA
-        cuda     onnxruntime_USE_NCCL
-        tensorrt onnxruntime_USE_TENSORRT
-        tensorrt onnxruntime_TENSORRT_PLACEHOLDER_BUILDER
-        directml onnxruntime_USE_DML
-        winml    onnxruntime_USE_WINML
-        coreml   onnxruntime_USE_COREML
-        mimalloc onnxruntime_USE_MIMALLOC
-        valgrind onnxruntime_USE_VALGRIND
-        xnnpack  onnxruntime_USE_XNNPACK
+        training  onnxruntime_ENABLE_TRAINING
+        training  onnxruntime_ENABLE_TRAINING_OPS
+        cuda      onnxruntime_USE_CUDA
+        cuda      onnxruntime_USE_NCCL
+        tensorrt  onnxruntime_USE_TENSORRT
+        tensorrt  onnxruntime_TENSORRT_PLACEHOLDER_BUILDER
+        directml  onnxruntime_USE_DML
+        winml     onnxruntime_USE_WINML
+        coreml    onnxruntime_USE_COREML
+        mimalloc  onnxruntime_USE_MIMALLOC
+        valgrind  onnxruntime_USE_VALGRIND
+        xnnpack   onnxruntime_USE_XNNPACK
+        test      onnxruntime_BUILD_UNIT_TESTS
+        framework onnxruntime_BUILD_APPLE_FRAMEWORK
     INVERTED_FEATURES
-        abseil onnxruntime_DISABLE_ABSEIL
+        abseil   onnxruntime_DISABLE_ABSEIL
 
 )
 
@@ -64,8 +81,11 @@ vcpkg_cmake_configure(
         # -DProtobuf_USE_STATIC_LIBS=OFF
         -DBUILD_PKGCONFIG_FILES=ON
         -Donnxruntime_BUILD_SHARED_LIB=${BUILD_SHARED}
-        -Donnxruntime_BUILD_APPLE_FRAMEWORK=${VCPKG_TARGET_IS_IOS}
-        -Donnxruntime_BUILD_UNIT_TESTS=OFF
+        -Donnxruntime_BUILD_OBJC=${VCPKG_TARGET_IS_IOS}
+        -Donnxruntime_BUILD_NODEJS=OFF
+        -Donnxruntime_BUILD_JAVA=OFF
+        -Donnxruntime_BUILD_CSHARP=OFF
+        -Donnxruntime_BUILD_WEBASSEMBLY=OFF
         -Donnxruntime_CROSS_COMPILING=${VCPKG_CROSSCOMPILING}
         -Donnxruntime_PREFER_SYSTEM_LIB=ON
         -Donnxruntime_USE_FULL_PROTOBUF=ON

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -11,6 +11,10 @@
     "date",
     "eigen3",
     "flatbuffers",
+    {
+      "name": "flatbuffers",
+      "host": true
+    },
     "nlohmann-json",
     {
       "name": "nsync",

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "onnxruntime",
-  "version-semver": "1.9.1",
-  "port-version": 1,
+  "version-semver": "1.12.1",
   "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
   "homepage": "www.onnxruntime.ai",
-  "supports": "(windows & !static) | linux | osx",
+  "supports": "windows | linux | osx",
   "dependencies": [
     "boost-config",
     "boost-mp11",
@@ -17,7 +16,7 @@
     "nsync",
     {
       "name": "nsync",
-      "platform": "linux"
+      "platform": "linux | osx"
     },
     "onnx",
     "optional-lite",
@@ -38,11 +37,24 @@
     "cuda": {
       "description": "Build with CUDA/NCCL support"
     },
+    "directml": {
+      "description": "Build with DirectML support",
+      "supports": "windows",
+      "dependencies": [
+        "directml"
+      ]
+    },
     "tensrorrt": {
       "description": "Build with NVIDIA TensorRT support"
     },
     "training": {
       "description": "Turn on build options for ML training"
+    },
+    "xnnpack": {
+      "description": "Build with XNNPack support",
+      "dependencies": [
+        "xnnpack"
+      ]
     }
   }
 }

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -13,7 +13,6 @@
     "eigen3",
     "flatbuffers",
     "nlohmann-json",
-    "nsync",
     {
       "name": "nsync",
       "platform": "linux | osx"
@@ -36,6 +35,9 @@
   "features": {
     "cuda": {
       "description": "Build with CUDA/NCCL support"
+    },
+    "coreml":{
+      "description" : "Build with CoreML support"
     },
     "directml": {
       "description": "Build with DirectML support",

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -3,7 +3,6 @@
   "version-semver": "1.12.1",
   "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
   "homepage": "www.onnxruntime.ai",
-  "supports": "windows | linux | osx",
   "dependencies": [
     "boost-config",
     "boost-mp11",
@@ -15,7 +14,7 @@
     "nlohmann-json",
     {
       "name": "nsync",
-      "platform": "linux | osx"
+      "platform": "!windows"
     },
     "onnx",
     "optional-lite",
@@ -33,11 +32,11 @@
     "zlib"
   ],
   "features": {
+    "coreml": {
+      "description": "Build with CoreML support"
+    },
     "cuda": {
       "description": "Build with CUDA/NCCL support"
-    },
-    "coreml":{
-      "description" : "Build with CoreML support"
     },
     "directml": {
       "description": "Build with DirectML support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -45,8 +45,8 @@
       "port-version": 0
     },
     "onnxruntime": {
-      "baseline": "1.9.1",
-      "port-version": 1
+      "baseline": "1.12.1",
+      "port-version": 0
     },
     "openssl3": {
       "baseline": "3.0.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2,7 +2,7 @@
   "default": {
     "cpuinfo": {
       "baseline": "2022-09-08",
-      "port-version": 0
+      "port-version": 1
     },
     "directml": {
       "baseline": "1.9.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,7 +41,7 @@
       "port-version": 0
     },
     "onnx": {
-      "baseline": "1.10.2",
+      "baseline": "1.12.0",
       "port-version": 0
     },
     "onnxruntime": {

--- a/versions/c-/cpuinfo.json
+++ b/versions/c-/cpuinfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7f107b52dca2f0bfaa513ebc5493df9726a750b",
+      "version-date": "2022-09-08",
+      "port-version": 1
+    },
+    {
       "git-tree": "94bc4cf3234fdca963485047fad7ab4e51063d9e",
       "version-date": "2022-09-08",
       "port-version": 0

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4df044138d042ad4f2ae202b657f7e32ab820414",
+      "version-semver": "1.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5b14f10634fdcd02f8eed5d05274aa447012a08e",
       "version-semver": "1.10.2",
       "port-version": 0

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e9976513df40336f407997fe169ff3f0d91c044",
+      "version-semver": "1.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "73564935a61beee5a58ecca29fc69bf8993055cd",
       "version-semver": "1.9.1",
       "port-version": 1

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "61d333fc24757c073fa147202fd8b44d7a0a4e7a",
+      "git-tree": "a2cb662e8cdeed04b4fd3774afcbd677f74a8c80",
       "version-semver": "1.12.1",
       "port-version": 0
     },

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e9976513df40336f407997fe169ff3f0d91c044",
+      "git-tree": "61d333fc24757c073fa147202fd8b44d7a0a4e7a",
       "version-semver": "1.12.1",
       "port-version": 0
     },


### PR DESCRIPTION
Resolve #40

### Changes

* `onnx`: 1.12.0
* `onnxruntime`: 1.12.1

#### cpuinfo

`cpuinfo` will create a shared library in the Linux environment.
`libcpuinfo_internal.a` contains some global variables and it's not installed.
`cpuinfo`  should be a shared library to contain them in the binary.
