### PR TITLE
CI: Support CircleCI for Windows port that requires large storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,27 @@ workflows:
               ignore:
                 - gh-pages
                 - docs
+      - deploy:
+          requires:
+            - windows_2022
+          filters:
+            branches:
+              only: main
 
 jobs:
+  deploy:
+    executor:
+      name: win/server-2022 # from the Orbs
+    steps:
+      - checkout
+      - run:
+          name: "Install Chocolatey packages"
+          command: |
+            choco install --yes --no-progress jq
+      - run:
+          name: "Print baseline.json"
+          command: Get-Content versions/baseline.json | jq
+
   windows_2022:
     executor:
       name: win/server-2022 # from the Orbs
@@ -28,7 +47,7 @@ jobs:
           name: "Install Chocolatey packages"
           command: |
             choco install --yes --no-progress `
-              rsync ninja jq
+              rsync ninja jq nuget.commandline
       - run:
           name: "Print baseline.json"
           command: |
@@ -51,14 +70,8 @@ jobs:
       - run:
           name: "Port: vcpkg-cmake"
           command: |
-            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
+            ./vcpkg.exe install --debug $env:OPT_CLEAN `
               vcpkg-cmake vcpkg-cmake-config
-          working_directory: vcpkg
-      - run:
-          name: "Port: cpuinfo"
-          command: |
-            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
-              cpuinfo
           working_directory: vcpkg
       - run:
           name: "Port: xnnpack"
@@ -66,6 +79,20 @@ jobs:
             ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
               xnnpack
           working_directory: vcpkg
+      - run:
+          name: "Port: from port-windows.text"
+          command: |
+            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
+              $(Get-Content "$env:CIRCLE_WORKING_DIRECTORY/.circleci/port-windows.txt")
+          working_directory: vcpkg
+          no_output_timeout: 2h
+      - run:
+          name: "Port: from port-uwp.text"
+          command: |
+            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
+              $(Get-Content "$env:CIRCLE_WORKING_DIRECTORY/.circleci/port-uwp.txt")
+          working_directory: vcpkg
+          no_output_timeout: 2h
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
           paths:
@@ -76,12 +103,12 @@ jobs:
           paths:
             - C:/Users/circleci/vcpkg-download-cache
           when: always
-      - run:
-          name: "Stage buildtrees logs"
-          command: rsync -r vcpkg/buildtrees/ buildtrees-log
-          when: always
+      # - run:
+      #     name: "Stage buildtrees logs"
+      #     command: rsync -r vcpkg/buildtrees/ buildtrees-log
+      #     when: always
       - store_artifacts:
           name: "Upload buildtrees log"
-          path: buildtrees-log
-          destination: "buildtrees"
+          path: vcpkg/buildtrees/ # buildtrees-log
+          destination: "build-logs"
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,15 @@ jobs:
       - run:
           name: "Show baseline.json"
           command: cat versions/baseline.json | jq
-
+      - run:
+          name: "Show environments"
+          command: |
+            Write-Output $env:VCPKG_DEFAULT_TRIPLET
+            Write-Output $env:CIRCLE_WORKING_DIRECTORY
+            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}/ports"
+            Write-Output $env:VCPKG_OVERLAY_PORTS
+          environment:
+            VCPKG_DEFAULT_TRIPLET: x64-uwp
+      - run:
+          name: "Clone microsoft/vcpkg"
+          command: git clone --branch=2022.04.12 --depth=1 https://github.com/microsoft/vcpkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+# https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+orbs:
+  win: circleci/windows@4.1.1
+  jq: circleci/jq@2.2.0
+
+workflows:
+  windows_workflow:
+    jobs:
+      - windows_ports
+
+jobs:
+  windows_ports:
+    executor:
+      name: win/default
+    steps:
+      - checkout
+      - run:
+          name: "Show baseline.json"
+          command: cat versions/baseline.json | jq
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,36 @@ jobs:
   windows_ports:
     executor:
       name: win/default
+    environment:
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+      VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
     steps:
       - checkout
       - run:
-          name: "Show baseline.json"
-          command: cat versions/baseline.json | jq
+          name: "Print baseline.json"
+          command: Get-Content versions/baseline.json | jq
       - run:
-          name: "Show environments"
+          name: "Setup: microsoft/vcpkg"
           command: |
-            Write-Output $env:VCPKG_DEFAULT_TRIPLET
-            Write-Output $env:CIRCLE_WORKING_DIRECTORY
-            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}/ports"
-            Write-Output $env:VCPKG_OVERLAY_PORTS
-          environment:
-            VCPKG_DEFAULT_TRIPLET: x64-uwp
+            git clone --branch=2022.04.12 --depth=1 https://github.com/microsoft/vcpkg
+            New-Item -Type Directory -Force -Path $env:VCPKG_DOWNLOADS
+            Push-Location vcpkg
+              ./bootstrap-vcpkg.bat
+              ./vcpkg.exe --version
+              ./vcpkg.exe fetch nuget
+            Pop-Location
+      - restore_cache:
+          keys:
+            - v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
+            - v1-vcpkg-download-cache
       - run:
-          name: "Clone microsoft/vcpkg"
-          command: git clone --branch=2022.04.12 --depth=1 https://github.com/microsoft/vcpkg
+          name: "Port: vcpkg-cmake"
+          command: |
+            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
+            Push-Location vcpkg
+              ./vcpkg install vcpkg-cmake
+            Pop-Location
+      - save_cache:
+          key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - C:/Users/circleci/vcpkg-download-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,10 @@ workflows:
 jobs:
   deploy:
     executor:
-      name: win/server-2022 # from the Orbs
+      name: win/server-2022
+    environment:
+      VCPKG_DOWNLOADS: C:/vcpkg-downloads
+      VCPKG_DEFAULT_BINARY_CACHE: C:/vcpkg-bins
     steps:
       - checkout
       - run:
@@ -33,12 +36,25 @@ jobs:
       - run:
           name: "Print baseline.json"
           command: Get-Content versions/baseline.json | jq
+      - run:
+          name: "Create cache folders"
+          command: |
+            New-Item -Type Directory -Force -Path $env:VCPKG_DOWNLOADS
+            New-Item -Type Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE
+      - restore_cache:
+          keys:
+            - v1-downloads-{{ checksum ".circleci/config.yml" }}
+      - restore_cache:
+          keys:
+            - v1-bins-{{ .Branch }}
 
   windows_2022:
     executor:
       name: win/server-2022 # from the Orbs
+      size: large
     environment:
-      VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
+      VCPKG_DOWNLOADS: C:/vcpkg-downloads
+      VCPKG_DEFAULT_BINARY_CACHE: C:/vcpkg-bins
       # VCPKG_DEFAULT_TRIPLET: x64-windows
       OPT_CLEAN: "--clean-buildtrees-after-build"
     steps:
@@ -49,13 +65,15 @@ jobs:
             choco install --yes --no-progress `
               rsync ninja jq nuget.commandline
       - run:
-          name: "Print baseline.json"
+          name: "Print with jq"
           command: |
-            Get-Content versions/baseline.json | jq
+            Get-Content .circleci/port-windows.txt | jq -Rn '[inputs]'
+            Get-Content .circleci/port-uwp.txt | jq -Rn '[inputs]'
       - run:
           name: "Setup: microsoft/vcpkg(2022.08.15)"
           command: |
             New-Item -Type Directory -Force -Path $env:VCPKG_DOWNLOADS
+            New-Item -Type Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE
             git clone --branch=2022.08.15 --depth=1 https://github.com/microsoft/vcpkg
             Push-Location vcpkg
               Get-Location
@@ -65,8 +83,8 @@ jobs:
             Pop-Location
       - restore_cache:
           keys:
-            - v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
-            - v1-vcpkg-download-cache-{{ .Branch }}
+            - v1-downloads-{{ checksum ".circleci/config.yml" }}
+            - v1-downloads-{{ .Branch }}
       - run:
           name: "Port: vcpkg-cmake"
           command: |
@@ -74,10 +92,10 @@ jobs:
               vcpkg-cmake vcpkg-cmake-config
           working_directory: vcpkg
       - run:
-          name: "Port: xnnpack"
+          name: "Port: onnxruntime"
           command: |
             ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
-              xnnpack
+              onnxruntime[directml]:x64-windows onnxruntime[xnnpack]:x64-uwp
           working_directory: vcpkg
       - run:
           name: "Port: from port-windows.text"
@@ -93,15 +111,23 @@ jobs:
               $(Get-Content "$env:CIRCLE_WORKING_DIRECTORY/.circleci/port-uwp.txt")
           working_directory: vcpkg
           no_output_timeout: 2h
+      - when:
+          condition:
+            equal: [ main, << pipeline.git.branch >> ]
+          steps:
+           - save_cache:
+              key: v1-bins-{{ .Branch }}
+              paths:
+                - C:/vcpkg-bins
       - save_cache:
-          key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
+          key: v1-downloads-{{ checksum ".circleci/config.yml" }}
           paths:
-            - C:/Users/circleci/vcpkg-download-cache
+            - C:/vcpkg-downloads
           when: always
       - save_cache:
-          key: v1-vcpkg-download-cache-{{ .Branch }}
+          key: v1-downloads-{{ .Branch }}
           paths:
-            - C:/Users/circleci/vcpkg-download-cache
+            - C:/vcpkg-downloads
           when: always
       # - run:
       #     name: "Stage buildtrees logs"
@@ -111,4 +137,3 @@ jobs:
           name: "Upload buildtrees log"
           path: vcpkg/buildtrees/ # buildtrees-log
           destination: "build-logs"
-          when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,12 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1.1
-  jq: circleci/jq@2.2.0
+  win: circleci/windows@5.0
 
 workflows:
-  windows_workflow:
+  windows_ports:
     jobs:
-      - windows_ports:
+      - windows_2022:
           filters:
             branches:
               ignore:
@@ -16,22 +15,23 @@ workflows:
                 - docs
 
 jobs:
-  windows_ports:
+  windows_2022:
     executor:
-      name: win/default
+      name: win/server-2022 # from the Orbs
     environment:
       VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
-      VCPKG_ROOT: C:/Users/circleci/project/vcpkg
       VCPKG_OVERLAY_PORTS: C:/Users/circleci/project/ports
+      # VCPKG_ROOT: C:/Users/circleci/project/vcpkg
       # VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
       # VCPKG_DEFAULT_TRIPLET: x64-windows
+      OPTS: "--clean-buildtrees-after-build "
     steps:
       - checkout
       - run:
           name: "Install Chocolatey packages"
           command: |
-            choco install --yes --no-progress rsync
-            choco install --yes --no-progress jq
+            choco install --yes --no-progress `
+              rsync ninja jq
       - run:
           name: "Print baseline.json"
           command: |
@@ -52,15 +52,15 @@ jobs:
             - v1-vcpkg-download-cache-{{ .Branch }}
       - run:
           name: "Port: vcpkg-cmake"
-          command: ./vcpkg.exe install vcpkg-cmake vcpkg-cmake-config
+          command: ./vcpkg.exe install $env:OPTS vcpkg-cmake vcpkg-cmake-config
           working_directory: vcpkg
       - run:
           name: "Port: cpuinfo"
-          command: ./vcpkg.exe install --clean-buildtrees-after-build cpuinfo
+          command: ./vcpkg.exe install $env:OPTS cpuinfo
           working_directory: vcpkg
       - run:
           name: "Port: xnnpack"
-          command: ./vcpkg.exe install --clean-buildtrees-after-build xnnpack
+          command: ./vcpkg.exe install $env:OPTS xnnpack
           working_directory: vcpkg
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,9 @@ jobs:
     environment:
       VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
       VCPKG_OVERLAY_PORTS: C:/Users/circleci/project/ports
-      # VCPKG_ROOT: C:/Users/circleci/project/vcpkg
-      # VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
+      VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
       # VCPKG_DEFAULT_TRIPLET: x64-windows
-      OPTS: "--clean-buildtrees-after-build "
+      OPT_CLEAN: "--clean-buildtrees-after-build"
     steps:
       - checkout
       - run:
@@ -42,6 +41,7 @@ jobs:
             New-Item -Type Directory -Force -Path $env:VCPKG_DOWNLOADS
             git clone --branch=2022.08.15 --depth=1 https://github.com/microsoft/vcpkg
             Push-Location vcpkg
+              Get-Location
               ./bootstrap-vcpkg.bat
               ./vcpkg.exe --version
               ./vcpkg.exe fetch nuget
@@ -52,15 +52,15 @@ jobs:
             - v1-vcpkg-download-cache-{{ .Branch }}
       - run:
           name: "Port: vcpkg-cmake"
-          command: ./vcpkg.exe install $env:OPTS vcpkg-cmake vcpkg-cmake-config
-          working_directory: vcpkg
+          command: ./vcpkg.exe install $env:OPT_CLEAN vcpkg-cmake vcpkg-cmake-config
+          working_directory: vcpkg # todo: shorten this
       - run:
           name: "Port: cpuinfo"
-          command: ./vcpkg.exe install $env:OPTS cpuinfo
+          command: ./vcpkg.exe install $env:OPT_CLEAN cpuinfo
           working_directory: vcpkg
       - run:
           name: "Port: xnnpack"
-          command: ./vcpkg.exe install $env:OPTS xnnpack
+          command: ./vcpkg.exe install $env:OPT_CLEAN xnnpack
           working_directory: vcpkg
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
     environment:
       VCPKG_DEFAULT_TRIPLET: x64-windows
       VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
+      VCPKG_ROOT: C:/Users/circleci/project/vcpkg
     steps:
       - checkout
       - run:
@@ -42,6 +43,20 @@ jobs:
             $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
             Push-Location vcpkg
               ./vcpkg install vcpkg-cmake
+            Pop-Location
+      - run:
+          name: "Port: xnnpack"
+          command: |
+            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
+            Push-Location vcpkg
+              ./vcpkg install xnnpack
+            Pop-Location
+      - run:
+          name: "Port: onnxruntime[xnnpack]"
+          command: |
+            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
+            Push-Location vcpkg
+              ./vcpkg install onnxruntime[xnnpack]
             Pop-Location
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,27 +8,39 @@ orbs:
 workflows:
   windows_workflow:
     jobs:
-      - windows_ports
+      - windows_ports:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - docs
 
 jobs:
   windows_ports:
     executor:
       name: win/default
     environment:
-      VCPKG_DEFAULT_TRIPLET: x64-windows
       VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
       VCPKG_ROOT: C:/Users/circleci/project/vcpkg
       VCPKG_OVERLAY_PORTS: C:/Users/circleci/project/ports
+      # VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
+      # VCPKG_DEFAULT_TRIPLET: x64-windows
     steps:
       - checkout
       - run:
+          name: "Install Chocolatey packages"
+          command: |
+            choco install --yes --no-progress rsync
+            choco install --yes --no-progress jq
+      - run:
           name: "Print baseline.json"
-          command: Get-Content versions/baseline.json | jq
+          command: |
+            Get-Content versions/baseline.json | jq
       - run:
           name: "Setup: microsoft/vcpkg(2022.08.15)"
           command: |
-            git clone --branch=2022.08.15 --depth=1 https://github.com/microsoft/vcpkg
             New-Item -Type Directory -Force -Path $env:VCPKG_DOWNLOADS
+            git clone --branch=2022.08.15 --depth=1 https://github.com/microsoft/vcpkg
             Push-Location vcpkg
               ./bootstrap-vcpkg.bat
               ./vcpkg.exe --version
@@ -40,17 +52,32 @@ jobs:
             - v1-vcpkg-download-cache-{{ .Branch }}
       - run:
           name: "Port: vcpkg-cmake"
-          command: |
-            ./vcpkg install vcpkg-cmake vcpkg-cmake-config
-          working_directory: C:/Users/circleci/project/vcpkg
-          # environment:
-          #   VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
+          command: ./vcpkg.exe install vcpkg-cmake vcpkg-cmake-config
+          working_directory: vcpkg
+      - run:
+          name: "Port: cpuinfo"
+          command: ./vcpkg.exe install --clean-buildtrees-after-build cpuinfo
+          working_directory: vcpkg
+      - run:
+          name: "Port: xnnpack"
+          command: ./vcpkg.exe install --clean-buildtrees-after-build xnnpack
+          working_directory: vcpkg
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
           paths:
             - C:/Users/circleci/vcpkg-download-cache
+          when: always
       - save_cache:
           key: v1-vcpkg-download-cache-{{ .Branch }}
           paths:
             - C:/Users/circleci/vcpkg-download-cache
-          
+          when: always
+      - run:
+          name: "Stage buildtrees logs"
+          command: rsync -r vcpkg/buildtrees/ buildtrees-log
+          when: always
+      - store_artifacts:
+          name: "Upload buildtrees log"
+          path: buildtrees-log
+          destination: "buildtrees"
+          when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,6 @@ jobs:
               vcpkg-cmake vcpkg-cmake-config
           working_directory: vcpkg
       - run:
-          name: "Port: onnxruntime"
-          command: |
-            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
-              onnxruntime[directml]:x64-windows onnxruntime[xnnpack]:x64-uwp
-          working_directory: vcpkg
-      - run:
           name: "Port: from port-windows.text"
           command: |
             ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
-            - v1-vcpkg-download-cache
+            - v1-vcpkg-download-cache-{{ .Branch }}
       - run:
           name: "Port: vcpkg-cmake"
           command: |
@@ -47,3 +47,8 @@ jobs:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
           paths:
             - C:/Users/circleci/vcpkg-download-cache
+      - save_cache:
+          key: v1-vcpkg-download-cache-{{ .Branch }}
+          paths:
+            - C:/Users/circleci/vcpkg-download-cache
+          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
           name: "Print baseline.json"
           command: Get-Content versions/baseline.json | jq
       - run:
-          name: "Setup: microsoft/vcpkg"
+          name: "Setup: microsoft/vcpkg(2022.08.15)"
           command: |
-            git clone --branch=2022.04.12 --depth=1 https://github.com/microsoft/vcpkg
+            git clone --branch=2022.08.15 --depth=1 https://github.com/microsoft/vcpkg
             New-Item -Type Directory -Force -Path $env:VCPKG_DOWNLOADS
             Push-Location vcpkg
               ./bootstrap-vcpkg.bat
@@ -42,7 +42,7 @@ jobs:
           command: |
             $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
             Push-Location vcpkg
-              ./vcpkg install vcpkg-cmake
+              ./vcpkg install vcpkg-cmake vcpkg-cmake-config
             Pop-Location
       - run:
           name: "Port: xnnpack"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: x64-windows
       VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
       VCPKG_ROOT: C:/Users/circleci/project/vcpkg
+      VCPKG_OVERLAY_PORTS: C:/Users/circleci/project/ports
     steps:
       - checkout
       - run:
@@ -40,24 +41,10 @@ jobs:
       - run:
           name: "Port: vcpkg-cmake"
           command: |
-            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
-            Push-Location vcpkg
-              ./vcpkg install vcpkg-cmake vcpkg-cmake-config
-            Pop-Location
-      - run:
-          name: "Port: xnnpack"
-          command: |
-            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
-            Push-Location vcpkg
-              ./vcpkg install xnnpack
-            Pop-Location
-      - run:
-          name: "Port: onnxruntime[xnnpack]"
-          command: |
-            $env:VCPKG_OVERLAY_PORTS="${env:CIRCLE_WORKING_DIRECTORY}\ports"
-            Push-Location vcpkg
-              ./vcpkg install onnxruntime[xnnpack]
-            Pop-Location
+            ./vcpkg install vcpkg-cmake vcpkg-cmake-config
+          working_directory: C:/Users/circleci/project/vcpkg
+          # environment:
+          #   VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ jobs:
       name: win/server-2022 # from the Orbs
     environment:
       VCPKG_DOWNLOADS: C:/Users/circleci/vcpkg-download-cache
-      VCPKG_OVERLAY_PORTS: C:/Users/circleci/project/ports
-      VCPKG_OVERLAY_TRIPLETS: C:/Users/circleci/project/triplets
       # VCPKG_DEFAULT_TRIPLET: x64-windows
       OPT_CLEAN: "--clean-buildtrees-after-build"
     steps:
@@ -52,15 +50,21 @@ jobs:
             - v1-vcpkg-download-cache-{{ .Branch }}
       - run:
           name: "Port: vcpkg-cmake"
-          command: ./vcpkg.exe install $env:OPT_CLEAN vcpkg-cmake vcpkg-cmake-config
-          working_directory: vcpkg # todo: shorten this
+          command: |
+            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
+              vcpkg-cmake vcpkg-cmake-config
+          working_directory: vcpkg
       - run:
           name: "Port: cpuinfo"
-          command: ./vcpkg.exe install $env:OPT_CLEAN cpuinfo
+          command: |
+            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
+              cpuinfo
           working_directory: vcpkg
       - run:
           name: "Port: xnnpack"
-          command: ./vcpkg.exe install $env:OPT_CLEAN xnnpack
+          command: |
+            ./vcpkg.exe install $env:OPT_CLEAN --overlay-ports="$env:CIRCLE_WORKING_DIRECTORY/ports" `
+              xnnpack
           working_directory: vcpkg
       - save_cache:
           key: v1-vcpkg-download-cache-{{ checksum ".circleci/config.yml" }}

--- a/.circleci/port-uwp.txt
+++ b/.circleci/port-uwp.txt
@@ -1,0 +1,3 @@
+xnnpack:x64-uwp
+xnnpack:arm64-uwp
+onnxruntime[xnnpack]:x64-uwp

--- a/.circleci/port-uwp.txt
+++ b/.circleci/port-uwp.txt
@@ -1,3 +1,1 @@
-xnnpack:x64-uwp
-xnnpack:arm64-uwp
 onnxruntime[xnnpack]:x64-uwp

--- a/.circleci/port-windows.txt
+++ b/.circleci/port-windows.txt
@@ -1,3 +1,1 @@
-xnnpack:x86-windows
-xnnpack:x64-windows
-xnnpack:arm64-windows
+onnxruntime[directml,xnnpack]:x64-windows

--- a/.circleci/port-windows.txt
+++ b/.circleci/port-windows.txt
@@ -1,0 +1,3 @@
+xnnpack:x86-windows
+xnnpack:x64-windows
+xnnpack:arm64-windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ trigger:
     exclude:
       - docs
       - gh-pages
+      - circleci*
 
 # pr:
 #   - main


### PR DESCRIPTION

### Description

CircleCI provides more storage than Azure Pipelines.
Port `onnxruntime` requires over 13GB storage for build output.
CircleCI Windows build will cover them.
