### PR TITLE
[fft2d] fix header copy failure

### DIFF
--- a/ports/fft2d/portfile.cmake
+++ b/ports/fft2d/portfile.cmake
@@ -18,14 +18,14 @@ vcpkg_download_distfile(FFT2D_HEADER_1
     FILENAME tensorflow-fft2d-header-1.txt
     SHA512 afaa5baf9c26d713ae02f3a1ee06d87bedd5a902d1d2a41c0e637aa205442647ba29908f86965d22015da13ac98a5c6f16d6febe8d7040a954eadc335158047a
 )
-file(RENAME ${FFT2D_HEADER_1} ${CURRENT_PACKAGES_DIR}/include/fft2d/fft.h)
+file(COPY ${FFT2D_HEADER_1} DESTINATION ${CURRENT_PACKAGES_DIR}/include/fft2d/fft.h)
 
 vcpkg_download_distfile(FFT2D_HEADER_2
     URLS "https://raw.githubusercontent.com/tensorflow/tensorflow/v2.7.0/third_party/fft2d/fft2d.h"
     FILENAME tensorflow-fft2d-header-2.txt
     SHA512 f4c581619882a819ed116053165cc0d6f8546b6229a3c56a6077ca939d982b306c50973723c04107985fcd0fb177e76fc78f9ca774a0173e5aacbad38e3fc394
 )
-file(RENAME ${FFT2D_HEADER_2} ${CURRENT_PACKAGES_DIR}/include/fft2d/fft2d.h)
+file(COPY ${FFT2D_HEADER_2} DESTINATION ${CURRENT_PACKAGES_DIR}/include/fft2d/fft2d.h)
 
 file(INSTALL ${SOURCE_PATH}/readme2d.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(INSTALL ${SOURCE_PATH}/readme.txt   DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/fft2d/vcpkg.json
+++ b/ports/fft2d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fft2d",
   "version": "1.0",
+  "port-version": 1,
   "description": "General Purpose FFT (Fast Fourier/Cosine/Sine Transform) Package",
   "homepage": "http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -22,7 +22,7 @@
     },
     "fft2d": {
       "baseline": "1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "gemmlowp": {
       "baseline": "2022-02-09",

--- a/versions/f-/fft2d.json
+++ b/versions/f-/fft2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f167e4eb9ceded3b67877428548789eb2dee3d1",
+      "version": "1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "86caa678f350ed3b876437d1f9a966824c7c72d3",
       "version": "1.0",
       "port-version": 0


### PR DESCRIPTION
## Port Change

### Description

`fft2d`'s `portfile.cmake` fails to rename the header files. Use [`file(COPY)`](https://cmake.org/cmake/help/latest/command/file.html#copy)

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "fft2d"
            ],
            "baseline": "..."
        }
    ]
}
```
