### PR TITLE
[system-qt5,system-qt6] Host port for Qt framework

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,12 +92,12 @@ stages:
               homebrew.packages: "qt@5"
               portname: "system-qt5"
               qt.root: "/usr/local/Cellar/qt@5/5.15.6"
-              qt5.dir: "/usr/local/Cellar/qt@5/5.15.6/lib/cmake/Qt5" # Qt5_DIR
+              QTDIR: "/usr/local/Cellar/qt@5/5.15.6/lib/cmake/Qt5" # Qt5_DIR
             qt6:
               homebrew.packages: "qt@6"
               portname: "system-qt6"
               qt.root: "/usr/local/Cellar/qt/6.3.2/"
-              qt6.dir: "/usr/local/Cellar/qt/6.3.2/lib/cmake/Qt6" # Qt6_DIR
+              QTDIR: "/usr/local/Cellar/qt/6.3.2/lib/cmake/Qt6" # Qt6_DIR
         steps:
           - powershell: brew install $(homebrew.packages) tree
             displayName: "Install HomeBrew packages"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,22 @@ stages:
             env:
               VCPKG_DEFAULT_TRIPLET: x64-ios-simulator
 
+  - stage: "Hosts"
+    jobs:
+      - job: "host_qt"
+        displayName: "Mac"
+        pool:
+          vmImage: macOS-12
+        strategy:
+          matrix:
+            qt5:
+              homebrew.packages: "qt@5"
+            qt6:
+              homebrew.packages: "qt@6"
+        steps:
+          - powershell: brew install $(homebrew.packages)
+            displayName: "Install HomeBrew packages"
+
   - stage: "Ports" # Check build status of the ports
     jobs:
       - job: "port_windows"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,9 +79,10 @@ stages:
             env:
               VCPKG_DEFAULT_TRIPLET: x64-ios-simulator
 
-  - stage: "Hosts"
+  - stage: "HostPorts"
+    dependsOn: "Triplets"
     jobs:
-      - job: "host_qt"
+      - job: "osx_host_qt"
         displayName: "Mac"
         pool:
           vmImage: macOS-12
@@ -95,7 +96,8 @@ stages:
           - powershell: brew install $(homebrew.packages)
             displayName: "Install HomeBrew packages"
 
-  - stage: "Ports" # Check build status of the ports
+  - stage: "Ports"
+    dependsOn: "Triplets"
     jobs:
       - job: "port_windows"
         displayName: "Windows"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,11 +90,24 @@ stages:
           matrix:
             qt5:
               homebrew.packages: "qt@5"
+              portname: "system-qt5"
+              qt.root: "/usr/local/Cellar/qt@5/5.15.6"
+              qt5.dir: "/usr/local/Cellar/qt@5/5.15.6/lib/cmake/Qt5" # Qt5_DIR
             qt6:
               homebrew.packages: "qt@6"
+              portname: "system-qt6"
+              qt.root: "/usr/local/Cellar/qt/6.3.2/"
+              qt6.dir: "/usr/local/Cellar/qt/6.3.2/lib/cmake/Qt6" # Qt6_DIR
         steps:
-          - powershell: brew install $(homebrew.packages)
+          - powershell: brew install $(homebrew.packages) tree
             displayName: "Install HomeBrew packages"
+          - powershell: tree -L 2 $(qt.root)
+            displayName: "Show Qt install location"
+          - task: run-vcpkg@0
+            displayName: "system-qt"
+            inputs:
+              vcpkgArguments: $(portname)
+              vcpkgGitCommitId: $(vcpkg.commit)
 
   - stage: "Ports"
     dependsOn: "Triplets"

--- a/ports/system-qt5/LICENSE
+++ b/ports/system-qt5/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/ports/system-qt5/portfile.cmake
+++ b/ports/system-qt5/portfile.cmake
@@ -1,0 +1,21 @@
+if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
+    message(WARNING "system-qt5 is a host-only port; please mark it as a host port in your dependencies.")
+endif()
+if(NOT DEFINED Qt5_DIR)
+    message(WARNING
+        "Requires Qt5_DIR. "
+        " set(\"C:/Qt/5.15.2/msvc2019_64/lib/cmake/Qt5\") or"
+        " set(\"/Users/user/Qt/5.15.2/clang_64/lib/cmake/Qt5\")"
+        " in your triplet"
+    )
+    message(FATAL_ERROR "Please define Qt5_DIR variable in the triplet.")
+endif()
+message(STATUS "Using Qt5: ${Qt5_DIR}")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/qt5_make_path_options.cmake"
+             "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/system-qt5/portfile.cmake
+++ b/ports/system-qt5/portfile.cmake
@@ -1,7 +1,12 @@
 if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
     message(WARNING "system-qt5 is a host-only port; please mark it as a host port in your dependencies.")
 endif()
-if(NOT DEFINED Qt5_DIR)
+
+if(DEFINED ENV{QTDIR})
+    set(Qt5_DIR "$ENV{QTDIR}")
+elseif(DEFINED ENV{Qt5_DIR})
+    set(Qt5_DIR "$ENV{Qt5_DIR}")
+elseif(NOT DEFINED Qt5_DIR)
     message(WARNING
         "Requires Qt5_DIR. "
         " set(\"C:/Qt/5.15.2/msvc2019_64/lib/cmake/Qt5\") or"

--- a/ports/system-qt5/portfile.cmake
+++ b/ports/system-qt5/portfile.cmake
@@ -2,10 +2,10 @@ if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
     message(WARNING "system-qt5 is a host-only port; please mark it as a host port in your dependencies.")
 endif()
 
-if(DEFINED ENV{QTDIR})
-    set(Qt5_DIR "$ENV{QTDIR}")
-elseif(DEFINED ENV{Qt5_DIR})
+if(DEFINED ENV{Qt5_DIR})
     set(Qt5_DIR "$ENV{Qt5_DIR}")
+elseif(DEFINED ENV{QTDIR})
+    set(Qt5_DIR "$ENV{QTDIR}")
 elseif(NOT DEFINED Qt5_DIR)
     message(WARNING
         "Requires Qt5_DIR. "

--- a/ports/system-qt5/qt5_make_path_options.cmake
+++ b/ports/system-qt5/qt5_make_path_options.cmake
@@ -1,0 +1,90 @@
+#[===[.md:
+# qt5_make_path_options.cmake
+
+In vcpkg.json file,
+
+```json
+{
+  "dependencies": [
+    {
+      "name": "system-qt5",
+      "host": true
+    }
+  ]
+}
+```
+
+In `portfile.cmake` file,
+
+```cmake
+qt6_make_path_options(qt5_path_options WITH_TOOLS
+COMPONENTS
+    Gui Widgets
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${qt6_path_options}
+)
+```
+
+#]===]
+if(Z_qt5_make_path_options_GUARD)
+    return()
+endif()
+set(Z_qt5_make_path_options_GUARD ON CACHE INTERNAL "Guard variable for 'qt5_make_path_options'")
+
+function(qt5_make_path_options out_var)
+    cmake_parse_arguments(PARSE_ARGV 1 arg "WITH_TOOLS" "Qt5_DIR" "COMPONENTS")
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+
+    # supported triplet?
+    if((NOT VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP) AND (NOT VCPKG_TARGET_IS_OSX))
+        message(WARNING "The triplet is not supported")
+    endif()
+
+    # the most importatnt option.
+    if((NOT DEFINED Qt5_DIR) AND (NOT DEFINED arg_Qt5_DIR))
+        message(FATAL_ERROR "Qt5_DIR is required for this function")
+    endif()
+    if(DEFINED arg_Qt5_DIR)
+        get_filename_component(Qt5_DIR "${arg_Qt5_DIR}" ABSOLUTE)
+    endif()
+    list(APPEND options -DQt5_DIR:PATH=${Qt5_DIR})
+
+    # ex) ".../msvc2019_64/lib/cmake/Qt5" -> ".../msvc2019_64/lib/cmake"
+    get_filename_component(qt5_cmake_dir "${Qt5_DIR}" PATH)
+
+    message(VERBOSE "Searching ${qt5_cmake_dir} ...")
+    if(DEFINED arg_WITH_TOOLS)
+        # ex) Qt5CoreTools, Qt5WidgetsTools, etc.
+        file(GLOB tool_folders "${qt5_cmake_dir}/Qt5*Tools")
+        foreach(tool_folder ${tool_folders})
+            get_filename_component(tool_name "${tool_folder}" NAME)
+            message(VERBOSE "  ${tool_name}")
+            list(APPEND options -D${tool_name}_DIR:PATH=${tool_folder})
+        endforeach()
+    endif()
+
+    message(VERBOSE "Checking components...")
+    if(DEFINED arg_COMPONENTS)
+        # ex) Core, Network ...
+        foreach(component IN LISTS arg_COMPONENTS)
+            message(VERBOSE "  ${component}")
+            list(APPEND options -DQt5${component}_DIR:PATH=${qt5_cmake_dir}/Qt5${component})
+        endforeach()
+    endif()
+
+    if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
+        set(extra WinExtras)
+        list(APPEND options -DQt5${extra}_DIR:PATH=${qt5_cmake_dir}/Qt5${extra})
+    elseif(VCPKG_TARGET_IS_OSX)
+        set(extra MacExtras)
+        list(APPEND options -DQt5${extra}_DIR:PATH=${qt5_cmake_dir}/Qt5${extra})
+    endif()
+
+    set("${out_var}" "${options}" PARENT_SCOPE)
+endfunction()

--- a/ports/system-qt5/vcpkg-port-config.cmake
+++ b/ports/system-qt5/vcpkg-port-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/qt5_make_path_options.cmake")

--- a/ports/system-qt5/vcpkg.json
+++ b/ports/system-qt5/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "system-qt5",
+  "version-date": "2022-10-25",
+  "license": "CC0-1.0"
+}

--- a/ports/system-qt6/LICENSE
+++ b/ports/system-qt6/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/ports/system-qt6/portfile.cmake
+++ b/ports/system-qt6/portfile.cmake
@@ -2,10 +2,10 @@ if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
     message(WARNING "system-qt6 is a host-only port; please mark it as a host port in your dependencies.")
 endif()
 
-if(DEFINED ENV{QTDIR})
-    set(Qt6_DIR "$ENV{QTDIR}")
-elseif(DEFINED ENV{Qt6_DIR})
+if(DEFINED ENV{Qt6_DIR})
     set(Qt6_DIR "$ENV{Qt6_DIR}")
+elseif(DEFINED ENV{QTDIR})
+    set(Qt6_DIR "$ENV{QTDIR}")
 elseif(NOT DEFINED Qt6_DIR)
     message(WARNING
         "Requires Qt6_DIR. "

--- a/ports/system-qt6/portfile.cmake
+++ b/ports/system-qt6/portfile.cmake
@@ -1,7 +1,12 @@
 if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
     message(WARNING "system-qt6 is a host-only port; please mark it as a host port in your dependencies.")
 endif()
-if(NOT DEFINED Qt6_DIR)
+
+if(DEFINED ENV{QTDIR})
+    set(Qt6_DIR "$ENV{QTDIR}")
+elseif(DEFINED ENV{Qt6_DIR})
+    set(Qt6_DIR "$ENV{Qt6_DIR}")
+elseif(NOT DEFINED Qt6_DIR)
     message(WARNING
         "Requires Qt6_DIR. "
         " set(\"C:/Qt/6.3.1/msvc2019_64/lib/cmake/Qt6\") or"

--- a/ports/system-qt6/portfile.cmake
+++ b/ports/system-qt6/portfile.cmake
@@ -1,0 +1,21 @@
+if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
+    message(WARNING "system-qt6 is a host-only port; please mark it as a host port in your dependencies.")
+endif()
+if(NOT DEFINED Qt6_DIR)
+    message(WARNING
+        "Requires Qt6_DIR. "
+        " set(\"C:/Qt/6.3.1/msvc2019_64/lib/cmake/Qt6\") or"
+        " set(\"/Users/user/Qt/6.3.1/macos/lib/cmake/Qt6\")"
+        " in your triplet"
+    )
+    message(FATAL_ERROR "Please define Qt6_DIR variable in the triplet.")
+endif()
+message(STATUS "Using Qt6: ${Qt6_DIR}")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/qt6_make_path_options.cmake"
+             "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/system-qt6/qt6_make_path_options.cmake
+++ b/ports/system-qt6/qt6_make_path_options.cmake
@@ -1,0 +1,83 @@
+#[===[.md:
+# qt6_make_path_options.cmake
+
+In vcpkg.json file,
+
+```json
+{
+  "dependencies": [
+    {
+      "name": "system-qt6",
+      "host": true
+    }
+  ]
+}
+```
+
+In `portfile.cmake` file,
+
+```cmake
+qt6_make_path_options(qt6_path_options WITH_TOOLS
+COMPONENTS
+    Gui Widgets
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${qt6_path_options}
+)
+```
+
+#]===]
+if(Z_qt6_make_path_options_GUARD)
+    return()
+endif()
+set(Z_qt6_make_path_options_GUARD ON CACHE INTERNAL "Guard variable for 'qt6_make_path_options'")
+
+function(qt6_make_path_options out_var)
+    cmake_parse_arguments(PARSE_ARGV 1 arg "WITH_TOOLS" "Qt6_DIR" "COMPONENTS")
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+
+    # supported triplet?
+    if((NOT VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP) AND (NOT VCPKG_TARGET_IS_OSX))
+        message(WARNING "The triplet is not supported")
+    endif()
+
+    # the most importatnt option.
+    if((NOT DEFINED Qt6_DIR) AND (NOT DEFINED arg_Qt6_DIR))
+        message(FATAL_ERROR "Qt6_DIR is required for this function")
+    endif()
+    if(DEFINED arg_Qt6_DIR)
+        get_filename_component(Qt6_DIR "${arg_Qt6_DIR}" ABSOLUTE)
+    endif()
+    list(APPEND options -DQt6_DIR:PATH=${Qt6_DIR})
+
+    # ex) ".../msvc2019_64/lib/cmake/Qt6" -> ".../msvc2019_64/lib/cmake"
+    get_filename_component(qt6_cmake_dir "${Qt6_DIR}" PATH)
+    list(APPEND options -DQt6Core5Compat_DIR:PATH=${qt6_cmake_dir}/Qt6Core5Compat)
+
+    message(VERBOSE "Searching ${qt6_cmake_dir} ...")
+    if(DEFINED arg_WITH_TOOLS)
+        # ex) Qt6CoreTools, Qt6WidgetsTools, etc.
+        file(GLOB tool_folders "${qt6_cmake_dir}/Qt6*Tools")
+        foreach(tool_folder ${tool_folders})
+            get_filename_component(tool_name "${tool_folder}" NAME)
+            message(VERBOSE "  ${tool_name}")
+            list(APPEND options -D${tool_name}_DIR:PATH=${tool_folder})
+        endforeach()
+    endif()
+
+    message(VERBOSE "Checking components...")
+    if(DEFINED arg_COMPONENTS)
+        # ex) Core, Network ...
+        foreach(component IN LISTS arg_COMPONENTS)
+            message(VERBOSE "  ${component}")
+            list(APPEND options -DQt6${component}_DIR:PATH=${qt6_cmake_dir}/Qt6${component})
+        endforeach()
+    endif()
+
+    set("${out_var}" "${options}" PARENT_SCOPE)
+endfunction()

--- a/ports/system-qt6/vcpkg-port-config.cmake
+++ b/ports/system-qt6/vcpkg-port-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/qt6_make_path_options.cmake")

--- a/ports/system-qt6/vcpkg.json
+++ b/ports/system-qt6/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "system-qt6",
+  "version-date": "2022-10-25",
+  "license": "CC0-1.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -56,6 +56,14 @@
       "baseline": "2022-09-12",
       "port-version": 0
     },
+    "system-qt5": {
+      "baseline": "2022-10-25",
+      "port-version": 0
+    },
+    "system-qt6": {
+      "baseline": "2022-10-25",
+      "port-version": 0
+    },
     "tensorflow-lite": {
       "baseline": "2.9.2",
       "port-version": 0

--- a/versions/s-/system-qt5.json
+++ b/versions/s-/system-qt5.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ef38d05d62aa1f9e29a2d054ccd0e5852fd5c160",
+      "version-date": "2022-10-25",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/system-qt6.json
+++ b/versions/s-/system-qt6.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a695f55d7a97645befd6a417f10829433ba116bf",
+      "version-date": "2022-10-25",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Port Change

### Description

* Project: [Qt Framework](https://www.qt.io/)
* Versions:
   * https://doc.qt.io/qt-5.15/ (5.15.2+)
   * https://doc.qt.io/qt-6/ (6.2+)

In vcpkg.json file,

```json
{
  "dependencies": [
    {
      "name": "system-qt6",
      "host": true
    }
  ]
}
```

In `portfile.cmake` file,

```cmake
qt6_make_path_options(qt6_path_options WITH_TOOLS
COMPONENTS
    Gui Widgets
)

vcpkg_cmake_configure(
    SOURCE_PATH "${SOURCE_PATH}"
    OPTIONS
        ${qt6_path_options}
)
```

### Triplet Support

* `x64-windows`
* `x64-osx`, `arm64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "system-qt5",
                "system-qt6"
            ],
            "baseline": "..."
        }
    ]
}
```
