### PR TITLE
[openssl3] update to 3.0.6

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.0.5
-    SHA512 e426f2d48dcd87ad938b246cea69988710198c3ed2f5bb9065aa9e74492161b056336f5b1f29be64e70dfd86a77808fe727ebb46eae10331c76f1ff08e341133
+    REF openssl-3.0.6
+    SHA512 539e1f5dc5c76e0bacaf7635d92f3f4b5138d95151de7dcefabfd71762a40be9fd8dbf740ceefd8bed901122454a409e88c3791c70d7a88e1fe08432ccdb5885
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.0.5",
+  "version-semver": "3.0.6",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -49,7 +49,7 @@
       "port-version": 1
     },
     "openssl3": {
-      "baseline": "3.0.5",
+      "baseline": "3.0.6",
       "port-version": 0
     },
     "ruy": {

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bbe24991a9d6dd228330e722c7d4b39a3bba3c3",
+      "version-semver": "3.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "c4fd0b6c419be72f4a91d36ef136ed00b04d917b",
       "version-semver": "3.0.5",
       "port-version": 0


### PR DESCRIPTION
## Port Change

### Description

* Project: [OpenSSL/OpenSSL](https://github.com/openssl/openssl)
* Version: "3.0.6" https://github.com/openssl/openssl/releases/tag/openssl-3.0.6

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl3"
            ],
            "baseline": "..."
        }
    ]
}
```
