### PR TITLE
[libdispatch] fix failure from VC++ stdatomic.h

### DIFF
--- a/ports/libdispatch/fix-cmake.patch
+++ b/ports/libdispatch/fix-cmake.patch
@@ -11,15 +11,16 @@ index 29a97fd..5373dd2 100644
    include(ClangClCompileRules)
  endif()
  
-@@ -193,6 +193,14 @@ check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
+@@ -193,6 +193,15 @@ check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
  check_include_files("sys/types.h" HAVE_SYS_TYPES_H)
  check_include_files("objc/objc-internal.h" HAVE_OBJC)
  
 +check_include_files("stdatomic.h" HAVE_STDATOMIC_H)
 +if(NOT HAVE_STDATOMIC_H)
-+  message(WARNING "<stdatomic.h> is required")
-+  find_library(ATOMIC_LIBPATH NAMES zenny_atomic REQUIRED) # see port 'zenny-atomic'
-+  link_libraries(${ATOMIC_LIBPATH})
++  find_library(ATOMIC_LIBPATH NAMES zenny_atomic) # see port 'zenny-atomic'
++  if(ATOMIC_LIBPATH)
++    link_libraries(${ATOMIC_LIBPATH})
++  endif()
 +  find_path(ATOMIC_INCLUDE_DIR NAMES "stdatomic.h" REQUIRED)
 +  include_directories(${ATOMIC_INCLUDE_DIR})
 +endif()

--- a/ports/libdispatch/fix-cmake.patch
+++ b/ports/libdispatch/fix-cmake.patch
@@ -20,9 +20,9 @@ index 29a97fd..5373dd2 100644
 +  message(WARNING "<stdatomic.h> is required")
 +  find_library(ATOMIC_LIBPATH NAMES zenny_atomic REQUIRED) # see port 'zenny-atomic'
 +  link_libraries(${ATOMIC_LIBPATH})
-+  include_directories(${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include) # todo: use find_file
++  find_path(ATOMIC_INCLUDE_DIR NAMES "stdatomic.h" REQUIRED)
++  include_directories(${ATOMIC_INCLUDE_DIR})
 +endif()
-+
  if(HAVE_MACH)
    set(USE_MACH_SEM 1)
  else()

--- a/ports/libdispatch/fix-sources-windows.patch
+++ b/ports/libdispatch/fix-sources-windows.patch
@@ -101,3 +101,21 @@ index c002e72..e44f3f5 100644
  #error libdispatch requires C11 with <stdatomic.h>
  #endif
  
+diff --git a/src/block.cpp b/src/block.cpp
+index 55f83c2..19d6d30 100644
+--- a/src/block.cpp
++++ b/src/block.cpp
+@@ -28,6 +28,13 @@
+ #error Must build without C++ exceptions
+ #endif
+ 
++#if defined(_MSC_VER) && defined(__STDC_HOSTED__) // include the toolchain(VC++, LLVM) <stdatomic.h>
++#  if __STDC_HOSTED__ 
++#    undef __STDC_HOSTED__
++#    define __STDC_HOSTED__ 0
++#  endif
++#endif
++
+ #include "internal.h"
+ 
+ // NOTE: this file must not contain any atomic operations

--- a/ports/libdispatch/vcpkg.json
+++ b/ports/libdispatch/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "libdispatch",
   "version-string": "swift-5.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The libdispatch Project, (a.k.a. Grand Central Dispatch), for concurrency on multicore hardware",
   "homepage": "https://github.com/apple/swift-corelibs-libdispatch",
   "license": "Apache-2.0",
-  "supports": "(windows & !static) | android",
+  "supports": "windows | android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libdispatch/vcpkg.json
+++ b/ports/libdispatch/vcpkg.json
@@ -10,10 +10,14 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "zenny-atomic",
-      "platform": "windows"
     }
-  ]
+  ],
+  "features": {
+    "zenny-atomic": {
+      "description": "Use zenny-atomic for platforms which doesn't support <stdatomic.h>",
+      "dependencies": [
+        "zenny-atomic"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -30,7 +30,7 @@
     },
     "libdispatch": {
       "baseline": "swift-5.5",
-      "port-version": 3
+      "port-version": 4
     },
     "libtorch": {
       "baseline": "1.10.0",

--- a/versions/l-/libdispatch.json
+++ b/versions/l-/libdispatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fab0134e318ae57e994fa83df0913c33a9ab04b2",
+      "version-string": "swift-5.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "58b7eee3b654b15cbb1a2acab29dae9b5c6b0e8e",
       "version-string": "swift-5.5",
       "port-version": 3

--- a/versions/l-/libdispatch.json
+++ b/versions/l-/libdispatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8bab102eff56dfd3037b5b93c3b3ca631acbe6df",
+      "git-tree": "c37b34d8fcd4ce5e252da0aa5f9c89469969e94e",
       "version-string": "swift-5.5",
       "port-version": 4
     },

--- a/versions/l-/libdispatch.json
+++ b/versions/l-/libdispatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fab0134e318ae57e994fa83df0913c33a9ab04b2",
+      "git-tree": "8bab102eff56dfd3037b5b93c3b3ca631acbe6df",
       "version-string": "swift-5.5",
       "port-version": 4
     },


### PR DESCRIPTION
## Port Change

### Description

* Project: [[]()](https://github.com/apple/swift-corelibs-libdispatch)
* Version: "swift 5.5"

### Triplet Support

* `x64-windows`
* `x86-windows`
* `arm64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "libdispatch"
            ],
            "baseline": "..."
        }
    ]
}
```
