### PR TITLE
[directml] update to 1.10.0

### DIFF
--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
 vcpkg_find_acquire_program(NUGET)
 
 set(PACKAGE_NAME    "Microsoft.AI.DirectML")
-set(PACKAGE_VERSION "1.9.1")
+set(PACKAGE_VERSION "1.10.0")
 
 file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME})
 vcpkg_execute_required_process(

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directml",
-  "version-semver": "1.9.1",
+  "version-semver": "1.10.0",
   "description": [
     "DirectML is a high-performance, hardware-accelerated DirectX 12 library for machine learning.",
     "DirectML provides GPU acceleration for common machine learning tasks across a broad range of supported hardware and drivers, ",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5,7 +5,7 @@
       "port-version": 2
     },
     "directml": {
-      "baseline": "1.9.1",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "eigen3": {

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5462253dc8f6421bbbc922306f078459536dfee0",
+      "version-semver": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a60f643fedab8c21a4fcb4075309653c7cc193b0",
       "version-semver": "1.9.1",
       "port-version": 0


### PR DESCRIPTION
## Port Change

### Description

* https://www.nuget.org/packages/Microsoft.AI.DirectML/1.10.0
* Version: "1.10.0"

Seems like the package supports Xbox. But I don't have a plan to support it.

### Triplet Support

* `x64-windows`
* `x86-windows`
* `arm-w64indows`
* `arm-windows`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "directml"
            ],
            "baseline": "..."
        }
    ]
}
```
