### PR TITLE
[apple-nio-ssl] Fix static/dynamic build with xcodebuild

### DIFF
--- a/ports/apple-nio-ssl/portfile.cmake
+++ b/ports/apple-nio-ssl/portfile.cmake
@@ -48,7 +48,14 @@ message(STATUS "Generating Xcode project from Package.swift")
 vcpkg_execute_required_process(
     COMMAND ${SWIFT} package generate-xcodeproj
     WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "swift-generate-${TARGET_TRIPLET}"
+    LOGNAME "generate-${TARGET_TRIPLET}"
+)
+
+message(STATUS "Recording project info")
+vcpkg_execute_required_process(
+    COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -list
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME "info-${TARGET_TRIPLET}"
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
@@ -80,16 +87,16 @@ endif()
 message(STATUS "Building ${TARGET_TRIPLET}-dbg")
 vcpkg_execute_required_process(
     COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -target CNIOBoringSSL -jobs ${VCPKG_CONCURRENCY}
-                -configuration Debug -sdk ${SDK} -arch ${ARCH}
+                -sdk ${SDK} -arch ${ARCH} -configuration Debug
     WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "xcodebuild-build-${TARGET_TRIPLET}-dbg"
+    LOGNAME "build-${TARGET_TRIPLET}-dbg"
 )
 message(STATUS "Building ${TARGET_TRIPLET}-rel")
 vcpkg_execute_required_process(
     COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -target CNIOBoringSSL -jobs ${VCPKG_CONCURRENCY}
-                -configuration Release -sdk ${SDK} -arch ${ARCH}
+                -sdk ${SDK} -arch ${ARCH} -configuration Release
     WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "xcodebuild-build-${TARGET_TRIPLET}-rel"
+    LOGNAME "build-${TARGET_TRIPLET}-rel"
 )
 
 set(OUT_FWK "CNIOBoringSSL.framework")

--- a/ports/apple-nio-ssl/portfile.cmake
+++ b/ports/apple-nio-ssl/portfile.cmake
@@ -1,7 +1,10 @@
 
-# MACH_O_TYPE = staticlib;
+# see https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    # By default, the project generates dynamic framework.
+    # These patches have NO effect. But may help debugging in the SOURCE_PATH ...
     list(APPEND SWIFTPM_PATCHES swiftpm-product-dynamic.patch)
+    # list(APPEND XCODEBUILD_PARAMS "MACH_O_TYPE=mh_dylib")
 elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(APPEND SWIFTPM_PATCHES swiftpm-product-static.patch)
     list(APPEND XCODEBUILD_PARAMS "MACH_O_TYPE=staticlib")
@@ -26,7 +29,6 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-# use source folder so `--editable` can take effect always
 # see vcpkg_extract_source_archive
 if(NOT _VCPKG_EDITABLE)
     file(REMOVE_RECURSE "${SOURCE_PATH}/.build" "${SOURCE_PATH}/build")
@@ -36,7 +38,6 @@ endif()
 get_filename_component(CUSTOM_BUILDTREES_DIR "${SOURCE_PATH}" PATH)
 file(CREATE_LINK "${NIO_SOURCE_PATH}" "${CUSTOM_BUILDTREES_DIR}/swift-nio" SYMBOLIC)
 
-# todo: add some comments
 function(swiftpm_generatate_xcodeproj)
     cmake_parse_arguments(PARSE_ARGV 0 swiftpm "" "LOGNAME" "PARAMS")
     if(DEFINED xc_UNPARSED_ARGUMENTS)
@@ -58,7 +59,6 @@ function(swiftpm_generatate_xcodeproj)
     )
 endfunction()
 
-# todo: add some comments
 function(xcodebuild_build_framework)
     cmake_parse_arguments(PARSE_ARGV 0 xc "COPY_AFTER_BUILD" "PROJECT;FRAMEWORK;OUTPUT_DIR;LOGNAME" "PARAMS")
     if(DEFINED xc_UNPARSED_ARGUMENTS)

--- a/ports/apple-nio-ssl/portfile.cmake
+++ b/ports/apple-nio-ssl/portfile.cmake
@@ -1,5 +1,10 @@
-if(VCPKG_TARGET_IS_IOS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# MACH_O_TYPE = staticlib;
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    list(APPEND SWIFTPM_PATCHES swiftpm-product-dynamic.patch)
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND SWIFTPM_PATCHES swiftpm-product-static.patch)
+    list(APPEND XCODEBUILD_PARAMS "MACH_O_TYPE=staticlib")
 endif()
 
 vcpkg_from_github(
@@ -8,16 +13,10 @@ vcpkg_from_github(
     REF 2.23.0
     SHA512 a7d4478f3ebd8dd1ee78c71afef610c33b74fb1b38054ef352dccbc454b8c56b30158c63d20d8468fa17e3f688445814ea743b841bbac28b8639bc81cef86632
     HEAD_REF main
+    PATCHES
+        swiftpm-use-local.patch
+        ${SWIFTPM_PATCHES}
 )
-# To Do: use .patch instead of this...
-# fix some part of Package.swift.
-vcpkg_replace_string("${SOURCE_PATH}/Package.swift" "/* This target" "//")
-vcpkg_replace_string("${SOURCE_PATH}/Package.swift" "MANGLE_END */" "//")
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    vcpkg_replace_string("${SOURCE_PATH}/Package.swift" "type: .static," "type: .dynamic,")
-elseif(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    vcpkg_replace_string("${SOURCE_PATH}/Package.swift" "type: .dynamic," "type: .static,")
-endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH NIO_SOURCE_PATH
@@ -28,35 +27,103 @@ vcpkg_from_github(
 )
 
 # use source folder so `--editable` can take effect always
-get_filename_component(CUSTOM_BUILDTREES_DIR "${SOURCE_PATH}" PATH)
 # see vcpkg_extract_source_archive
 if(NOT _VCPKG_EDITABLE)
     file(REMOVE_RECURSE "${SOURCE_PATH}/.build" "${SOURCE_PATH}/build")
 endif()
 
 # use symbolic link to prevent SwiftPM checkouts
-set(ENV{SWIFTCI_USE_LOCAL_DEPS} "TRUE")
+get_filename_component(CUSTOM_BUILDTREES_DIR "${SOURCE_PATH}" PATH)
 file(CREATE_LINK "${NIO_SOURCE_PATH}" "${CUSTOM_BUILDTREES_DIR}/swift-nio" SYMBOLIC)
 
-# find required tools to build
-find_program(SWIFT NAMES swift REQUIRED)
-message(STATUS "Detected swift: ${SWIFT}")
-find_program(XCODEBUILD NAMES xcodebuild REQUIRED)
-message(STATUS "Detected xcodebuild: ${XCODEBUILD}")
+# todo: add some comments
+function(swiftpm_generatate_xcodeproj)
+    cmake_parse_arguments(PARSE_ARGV 0 swiftpm "" "LOGNAME" "PARAMS")
+    if(DEFINED xc_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} can't handle extra arguments: ${xc_UNPARSED_ARGUMENTS}")
+    endif()
+    if(NOT DEFINED swiftpm_LOGNAME)
+        set(swiftpm_LOGNAME "generate")
+    endif()
+    if(NOT DEFINED swiftpm_WORKING_DIRECTORY)
+        set(swiftpm_WORKING_DIRECTORY "${SOURCE_PATH}")
+    endif()
 
-message(STATUS "Generating Xcode project from Package.swift")
-vcpkg_execute_required_process(
-    COMMAND ${SWIFT} package generate-xcodeproj
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "generate-${TARGET_TRIPLET}"
-)
+    find_program(SWIFT NAMES swift REQUIRED)
+    message(STATUS "Generating Xcode project from Package.swift")
+    vcpkg_execute_required_process(
+        COMMAND ${SWIFT} package generate-xcodeproj ${swiftpm_PARAMS}
+        WORKING_DIRECTORY ${swiftpm_WORKING_DIRECTORY}
+        LOGNAME "${swiftpm_LOGNAME}-${TARGET_TRIPLET}"
+    )
+endfunction()
 
-message(STATUS "Recording project info")
-vcpkg_execute_required_process(
-    COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -list
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "info-${TARGET_TRIPLET}"
-)
+# todo: add some comments
+function(xcodebuild_build_framework)
+    cmake_parse_arguments(PARSE_ARGV 0 xc "COPY_AFTER_BUILD" "PROJECT;FRAMEWORK;OUTPUT_DIR;LOGNAME" "PARAMS")
+    if(DEFINED xc_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} can't handle extra arguments: ${xc_UNPARSED_ARGUMENTS}")
+    endif()
+    # required arguments
+    if(NOT DEFINED xc_PROJECT)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} requires: PROJECT")
+    endif()
+    set(PROJECT_FILENAME "${xc_PROJECT}.xcodeproj")
+
+    if(NOT DEFINED xc_FRAMEWORK)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} requires: FRAMEWORK")
+    endif()
+    set(FRAMEWORK_FILENAME "${xc_FRAMEWORK}.framework")
+
+    # optional arguments with default values
+    if(NOT DEFINED xc_LOGNAME)
+        set(xc_LOGNAME "build")
+    endif()
+    if(NOT DEFINED xc_WORKING_DIRECTORY)
+        set(xc_WORKING_DIRECTORY "${SOURCE_PATH}")
+    endif()
+    if(NOT DEFINED xc_OUTPUT_DIR)
+        get_filename_component(xc_OUTPUT_DIR "${xc_WORKING_DIRECTORY}/build" ABSOLUTE)
+    endif()
+
+    # expected build output location of Package.swift generated xcodeproj
+    if(VCPKG_TARGET_IS_OSX)
+        get_filename_component(OUTPUT_DIR_DBG ${xc_OUTPUT_DIR}/Debug    ABSOLUTE)
+        get_filename_component(OUTPUT_DIR_REL ${xc_OUTPUT_DIR}/Release  ABSOLUTE)
+    elseif(VCPKG_TARGET_IS_IOS)
+        get_filename_component(OUTPUT_DIR_DBG ${xc_OUTPUT_DIR}/Debug-iphoneos   ABSOLUTE)
+        get_filename_component(OUTPUT_DIR_REL ${xc_OUTPUT_DIR}/Release-iphoneos ABSOLUTE)
+        if(VCPKG_TARGET_IS_SIMULATOR)
+            get_filename_component(OUTPUT_DIR_DBG ${xc_OUTPUT_DIR}/Debug-iphonesimulator    ABSOLUTE)
+            get_filename_component(OUTPUT_DIR_REL ${xc_OUTPUT_DIR}/Release-iphonesimulator  ABSOLUTE)
+        endif()
+    else()
+        message(FATAL_ERROR "Unsupported target platform")
+    endif()
+
+    # Let's start build with xcodebuild ...
+    find_program(XCODEBUILD NAMES xcodebuild REQUIRED)
+
+    message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+    vcpkg_execute_required_process(
+        COMMAND ${XCODEBUILD} -project ${PROJECT_FILENAME} -target ${xc_FRAMEWORK} -jobs ${VCPKG_CONCURRENCY} -configuration Debug ${xc_PARAMS}
+        WORKING_DIRECTORY ${xc_WORKING_DIRECTORY}
+        LOGNAME "${xc_LOGNAME}-${TARGET_TRIPLET}-dbg"
+    )
+    if(xc_COPY_AFTER_BUILD)
+        file(COPY "${OUTPUT_DIR_DBG}/${FRAMEWORK_FILENAME}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    endif()
+
+    message(STATUS "Building ${TARGET_TRIPLET}-rel")
+    vcpkg_execute_required_process(
+        COMMAND ${XCODEBUILD} -project ${PROJECT_FILENAME} -target ${xc_FRAMEWORK} -jobs ${VCPKG_CONCURRENCY} -configuration Release ${xc_PARAMS}
+        WORKING_DIRECTORY ${xc_WORKING_DIRECTORY}
+        LOGNAME "${xc_LOGNAME}-${TARGET_TRIPLET}-rel"
+    )
+    if(xc_COPY_AFTER_BUILD)
+        file(COPY "${OUTPUT_DIR_REL}/${FRAMEWORK_FILENAME}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endfunction()
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     set(ARCH "arm64")
@@ -68,61 +135,60 @@ endif()
 
 if(VCPKG_TARGET_IS_OSX)
     set(SDK macosx)
-    set(OUTPUT_PATH_DBG ${SOURCE_PATH}/build/Debug)
-    set(OUTPUT_PATH_REL ${SOURCE_PATH}/build/Release)
 elseif(VCPKG_TARGET_IS_IOS)
     set(SDK iphoneos)
     if(VCPKG_TARGET_IS_SIMULATOR)
         set(SDK iphonesimulator)
-        set(OUTPUT_PATH_DBG ${SOURCE_PATH}/build/Debug-iphonesimulator)
-        set(OUTPUT_PATH_REL ${SOURCE_PATH}/build/Release-iphonesimulator)
-    else()
-        set(OUTPUT_PATH_DBG ${SOURCE_PATH}/build/Debug-iphoneos)
-        set(OUTPUT_PATH_REL ${SOURCE_PATH}/build/Release-iphoneos)
     endif()
 else()
     message(FATAL_ERROR "Unsupported target platform")
 endif()
 
-message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+# generate xcodeproject: swift-nio-ssl.xcodeproj
+find_program(SWIFT NAMES swift REQUIRED)
+message(STATUS "Using swift: ${SWIFT}")
+swiftpm_generatate_xcodeproj(LOGNAME "generate")
+
+find_program(XCODEBUILD NAMES xcodebuild REQUIRED)
+message(STATUS "Using xcodebuild: ${XCODEBUILD}")
+message(STATUS "  -sdk ${SDK} -arch ${ARCH}")
+if(DEFINED XCODEBUILD_PARAMS)
+message(STATUS "  ${XCODEBUILD_PARAMS}")
+endif()
+
+# before build, record some project info for CI environment debugging
 vcpkg_execute_required_process(
-    COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -target CNIOBoringSSL -jobs ${VCPKG_CONCURRENCY}
-                -sdk ${SDK} -arch ${ARCH} -configuration Debug
+    COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -list
     WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "build-${TARGET_TRIPLET}-dbg"
-)
-message(STATUS "Building ${TARGET_TRIPLET}-rel")
-vcpkg_execute_required_process(
-    COMMAND ${XCODEBUILD} -project swift-nio-ssl.xcodeproj -target CNIOBoringSSL -jobs ${VCPKG_CONCURRENCY}
-                -sdk ${SDK} -arch ${ARCH} -configuration Release
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME "build-${TARGET_TRIPLET}-rel"
+    LOGNAME "project-${TARGET_TRIPLET}"
 )
 
-set(OUT_FWK "CNIOBoringSSL.framework")
-
-file(COPY ${OUTPUT_PATH_DBG}/${OUT_FWK} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-file(COPY ${OUTPUT_PATH_REL}/${OUT_FWK} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+# build some targets
+xcodebuild_build_framework(PROJECT swift-nio-ssl FRAMEWORK CNIOBoringSSL
+    PARAMS -sdk ${SDK} -arch ${ARCH} ${XCODEBUILD_PARAMS}
+    LOGNAME "build1" COPY_AFTER_BUILD
+)
+xcodebuild_build_framework(PROJECT swift-nio-ssl FRAMEWORK CNIOBoringSSLShims
+    PARAMS -sdk ${SDK} -arch ${ARCH} ${XCODEBUILD_PARAMS}
+    LOGNAME "build2" COPY_AFTER_BUILD
+)
 
 # install public/private headers
 file(GLOB headers
-    ${SOURCE_PATH}/Sources/CNIOBoringSSL/include/*.h
+    "${SOURCE_PATH}/Sources/CNIOBoringSSL/include/*.h"
 )
-file(INSTALL ${headers} DESTINATION ${CURRENT_PACKAGES_DIR}/include/CNIOBoringSSL)
+file(INSTALL ${headers} DESTINATION "${CURRENT_PACKAGES_DIR}/include/CNIOBoringSSL")
 
 file(GLOB ssl_headers
-    ${SOURCE_PATH}/Sources/CNIOBoringSSL/ssl/*.h
+    "${SOURCE_PATH}/Sources/CNIOBoringSSL/ssl/*.h"
+    # ...
 )
-file(INSTALL ${ssl_headers} DESTINATION ${CURRENT_PACKAGES_DIR}/include/ssl)
+file(INSTALL ${ssl_headers} DESTINATION "${CURRENT_PACKAGES_DIR}/include/ssl")
 
 file(GLOB crypto_headers
-    ${SOURCE_PATH}/Sources/CNIOBoringSSL/crypto/*.h
+    "${SOURCE_PATH}/Sources/CNIOBoringSSL/crypto/internal.h"
+    # ...
 )
-file(INSTALL ${crypto_headers} DESTINATION ${CURRENT_PACKAGES_DIR}/include/crypto)
-
-
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/lib/${OUT_FWK}/Versions/A/_CodeSignature"
-)
+file(INSTALL ${crypto_headers} DESTINATION "${CURRENT_PACKAGES_DIR}/include/crypto")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/apple-nio-ssl/swiftpm-product-dynamic.patch
+++ b/ports/apple-nio-ssl/swiftpm-product-dynamic.patch
@@ -1,0 +1,15 @@
+diff --git a/Package.swift b/Package.swift
+index 8f696fd..e4ff201 100644
+--- a/Package.swift
++++ b/Package.swift
+@@ -52,9 +52,7 @@ let package = Package(
+         .library(name: "NIOSSL", targets: ["NIOSSL"]),
+         .executable(name: "NIOTLSServer", targets: ["NIOTLSServer"]),
+         .executable(name: "NIOSSLHTTP1Client", targets: ["NIOSSLHTTP1Client"]),
+-/* This target is used only for symbol mangling. It's added and removed automatically because it emits build warnings. MANGLE_START
+-        .library(name: "CNIOBoringSSL", type: .static, targets: ["CNIOBoringSSL"]),
+-MANGLE_END */
++        .library(name: "CNIOBoringSSL", type: .dynamic, targets: ["CNIOBoringSSL"]),
+     ],
+     dependencies: generateDependencies(),
+     targets: [

--- a/ports/apple-nio-ssl/swiftpm-product-static.patch
+++ b/ports/apple-nio-ssl/swiftpm-product-static.patch
@@ -1,0 +1,15 @@
+diff --git a/Package.swift b/Package.swift
+index 8f696fd..e4ff201 100644
+--- a/Package.swift
++++ b/Package.swift
+@@ -52,9 +52,7 @@ let package = Package(
+         .library(name: "NIOSSL", targets: ["NIOSSL"]),
+         .executable(name: "NIOTLSServer", targets: ["NIOTLSServer"]),
+         .executable(name: "NIOSSLHTTP1Client", targets: ["NIOSSLHTTP1Client"]),
+-/* This target is used only for symbol mangling. It's added and removed automatically because it emits build warnings. MANGLE_START
+-        .library(name: "CNIOBoringSSL", type: .static, targets: ["CNIOBoringSSL"]),
+-MANGLE_END */
++        .library(name: "CNIOBoringSSL", type: .static, targets: ["CNIOBoringSSL"]), // todo: check CNIOBoringSSLShims
+     ],
+     dependencies: generateDependencies(),
+     targets: [

--- a/ports/apple-nio-ssl/swiftpm-use-local.patch
+++ b/ports/apple-nio-ssl/swiftpm-use-local.patch
@@ -1,0 +1,13 @@
+diff --git a/Package.swift b/Package.swift
+index fe72932..8f696fd 100644
+--- a/Package.swift
++++ b/Package.swift
+@@ -34,7 +34,7 @@ import class Foundation.ProcessInfo
+ /// of the Swift toolchain, and so need to use local checkouts of our
+ /// dependencies.
+ func generateDependencies() -> [Package.Dependency] {
+-    if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
++    if false {
+         return [
+             .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+             .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/ports/apple-nio-ssl/vcpkg.json
+++ b/ports/apple-nio-ssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "apple-nio-ssl",
   "version": "2.23.0",
+  "port-version": 1,
   "description": "TLS Support for SwiftNIO, based on BoringSSL",
   "homepage": "https://github.com/apple/swift-nio-ssl",
   "license": "Apache-2.0",

--- a/versions/a-/apple-nio-ssl.json
+++ b/versions/a-/apple-nio-ssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd8180ca52d320347205bc2d7273ea619867afbd",
+      "git-tree": "07a7536b39abcd83fd64ea90cb7cc68fc265cabe",
       "version": "2.23.0",
       "port-version": 1
     },

--- a/versions/a-/apple-nio-ssl.json
+++ b/versions/a-/apple-nio-ssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd8180ca52d320347205bc2d7273ea619867afbd",
+      "version": "2.23.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4542ed26c903c66ee2d44a9a9dd00de7fe60b080",
       "version": "2.23.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "apple-nio-ssl": {
       "baseline": "2.23.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cpuinfo": {
       "baseline": "2022-09-08",


### PR DESCRIPTION
## Port Change

Bugfix of #82 `apple-nio-ssl` port.

### Description

Same version. Create/use 2 functions

* `swiftpm_generatate_xcodeproj`: Generate `.xcodeproj` from Package.swift (Swift Package Manager, SwiftPM)
* `xcodebuild_build_framework`: Build/Copy `.framework` from generated xcodeproj

### Triplet Support

* `x64-osx`
* `arm64-osx`
* `arm64-ios`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "apple-nio-ssl"
            ],
            "baseline": "..."
        }
    ]
}
```
