### PR TITLE
[directml] update to 1.10.1

### DIFF
--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -1,8 +1,9 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+# see https://www.nuget.org/packages/Microsoft.AI.DirectML/
 vcpkg_find_acquire_program(NUGET)
 
 set(PACKAGE_NAME    "Microsoft.AI.DirectML")
-set(PACKAGE_VERSION "1.10.0")
+set(PACKAGE_VERSION "1.10.1")
 
 file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME})
 vcpkg_execute_required_process(

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directml",
-  "version-semver": "1.10.0",
+  "version-semver": "1.10.1",
   "description": [
     "DirectML is a high-performance, hardware-accelerated DirectX 12 library for machine learning.",
     "DirectML provides GPU acceleration for common machine learning tasks across a broad range of supported hardware and drivers, ",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5,7 +5,7 @@
       "port-version": 2
     },
     "directml": {
-      "baseline": "1.10.0",
+      "baseline": "1.10.1",
       "port-version": 0
     },
     "eigen3": {

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50bc7af0945ca73159b36b2c0ecc10733f5d643a",
+      "version-semver": "1.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "5462253dc8f6421bbbc922306f078459536dfee0",
       "version-semver": "1.10.0",
       "port-version": 0


### PR DESCRIPTION
## Port Change

Previous work #79 

### Description

* Project: https://github.com/microsoft/DirectML
* Version: "1.10.1" https://www.nuget.org/packages/Microsoft.AI.DirectML/

### Triplet Support

* `x64-windows`
* `x86-windows`
* `arm64-windows`
* `arm-windows`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "directml"
            ],
            "baseline": "..."
        }
    ]
}
```
