### PR TITLE
[tensorflow-lite] update to 2.9.3

### DIFF
--- a/ports/tensorflow-lite/portfile.cmake
+++ b/ports/tensorflow-lite/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tensorflow/tensorflow
-    REF v2.9.2
-    SHA512 1d2c024b7b7abf6c44871a6ff7c513474ba1e12e0851f49f36057c1ddf27afdc8ef33c55db1e831ad3fe9fb2623ba23fff25af60508b9078001cdefd5268d55e
+    REF v2.9.3
+    SHA512 31cc11e166454e4ec8c27355990081d4a763fb83a1d6da6e44dc47a2c27cc7be8188b2af2e8ecd9789da0bf28500e57e178a100c74dfce670a7dc7fd3f5e2da3
     PATCHES
         fix-cmake.patch
         fix-source.patch

--- a/ports/tensorflow-lite/vcpkg.json
+++ b/ports/tensorflow-lite/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tensorflow-lite",
-  "version-semver": "2.9.2",
-  "port-version": 2,
+  "version-semver": "2.9.3",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://www.tensorflow.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -73,8 +73,8 @@
       "port-version": 0
     },
     "tensorflow-lite": {
-      "baseline": "2.9.2",
-      "port-version": 2
+      "baseline": "2.9.3",
+      "port-version": 0
     },
     "tensorpipe": {
       "baseline": "2021-11-13",

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4f6354331ef2ce91a8f6bb931183d9cc68fc594",
+      "version-semver": "2.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8630ae104a0feef6d6f613e0ef11b417c51268aa",
       "version-semver": "2.9.2",
       "port-version": 2


### PR DESCRIPTION

## Port Change

### Description

* https://github.com/tensorflow/tensorflow/releases/tag/v2.9.3

### Triplet Support

Same with current support

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "tensorflow-lite"
            ],
            "baseline": "..."
        }
    ]
}
```
