### PR TITLE
[google-jni-bind] create a new port

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ schedules:
 
 variables:
   - name: vcpkg.commit
-    value: "cef0b3ec767df6e83806899fe9525f6cf8d7bc91" # mainstream 2022.06.16.1
+    value: "94ce0dab56f4d8ba6bd631ba59ed682b02d45c46" # mainstream 2022.10.19
   - name: vcpkg.overlay.ports # == VCPKG_OVERLAY_PORTS
     value: $(Build.SourcesDirectory)/ports # --overlay-ports $(Build.SourcesDirectory)/ports
   - name: vcpkg.disable.metrics
@@ -508,14 +508,14 @@ stages:
             displayName: "arm64-ios"
             inputs:
               vcpkgArguments: "tensorflow-lite openssl3 metal-cpp xnnpack zlib-ng"
-              vcpkgGitCommitId: 81d08b03fadf7a8bf7a56b3f3b916e3d205a7b30
+              vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-ios
           - task: run-vcpkg@0
             displayName: "arm64-ios-simulator"
             inputs:
               vcpkgArguments: "tensorflow-lite openssl3 xnnpack"
-              vcpkgGitCommitId: 81d08b03fadf7a8bf7a56b3f3b916e3d205a7b30
+              vcpkgGitCommitId: $(vcpkg.commit)
             env:
               VCPKG_DEFAULT_TRIPLET: arm64-ios-simulator
           - task: run-vcpkg@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -384,7 +384,7 @@ stages:
           - task: run-vcpkg@0
             displayName: "Default Triplet"
             inputs:
-              vcpkgArguments: "openssl3 zlib-ng libdispatch fft2d farmhash ruy eigen3"
+              vcpkgArguments: "openssl3 zlib-ng libdispatch fft2d farmhash ruy eigen3 google-jni-bind"
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: CopyFiles@2
             displayName: "Copy logs in buildtrees"

--- a/ports/google-jni-bind/CMakeLists.txt
+++ b/ports/google-jni-bind/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.24)
+project(google-jni-bind LANGUAGES CXX)
+include(GNUInstallDirs)
+
+option(BUILD_TESTING "Build test programs" ON)
+
+find_package(JNI REQUIRED) # JNI::JNI
+
+install(FILES jni_bind_release.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+if(NOT BUILD_TESTING)
+    return()
+endif()
+

--- a/ports/google-jni-bind/portfile.cmake
+++ b/ports/google-jni-bind/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/jni-bind
+    REF fb9f3f669edc7e68ae16402dd2083c806d5a009d # visited 2023-02-24
+    SHA512 3ba2b29cc2e2721bda9fc7073623e65506288c31e783c53b744d9eacd03a9ffc9ca534351f84071f10feb90daf58cbc4e5aa71f3ba8e5c73a52eb1571a5250ab
+    HEAD_REF main
+    # PATCHES
+    #     fix-cmake.patch
+)
+# Install headers and a shim library with JackWeakAPI.c
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+if(DEFINED ENV{JAVA_HOME})
+    message(STATUS "Using JAVA_HOME: $ENV{JAVA_HOME}")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+vcpkg_cmake_install()
+# vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/jni-bind)
+# vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/google-jni-bind/vcpkg.json
+++ b/ports/google-jni-bind/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "google-jni-bind",
+  "version-date": "2023-02-24",
+  "description": "JNI Bind is a set of advanced syntactic sugar for writing efficient correct JNI Code in C++17 (and up)",
+  "homepage": "https://github.com/google/jni-bind",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -36,6 +36,10 @@
       "baseline": "2022-02-09",
       "port-version": 1
     },
+    "google-jni-bind": {
+      "baseline": "2023-02-24",
+      "port-version": 0
+    },
     "libdispatch": {
       "baseline": "swift-5.5",
       "port-version": 4

--- a/versions/g-/google-jni-bind.json
+++ b/versions/g-/google-jni-bind.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9547945acadebbbdc924dbebdefbf4b96315fff3",
+      "version-date": "2023-02-24",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Port Change

### Description

* https://github.com/google/jni-bind

### Triplet Support

Header only port. Currently considers Android JNI

* `arm64-android`
* `arm-neon-android`
* `x64-android`
* `x86-android`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "google-jni-bind"
            ],
            "baseline": "..."
        }
    ]
}
```
