### PR TITLE
[openssl3] update to 3.1.0

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -2,18 +2,11 @@ if(EXISTS ${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h)
     message(FATAL_ERROR "Can't build '${PORT}' if another SSL library is installed. Please remove existing one and try install '${PORT}' again if you need it.")
 endif()
 
-# 3.0.8 - LNK2019 `_umul128` in function `_mul_limb`
-vcpkg_download_distfile(MSVC_INTRINSIC_PATCH_PATH
-    URLS "https://github.com/openssl/openssl/commit/075652f224479dad2e64b92e791b296177af8705.diff"
-    FILENAME msvc-intrinsic.patch
-    SHA512 6b1910408e3727dcdd59727f12c3d4237ef7c77d3e8aed336795e0e4aeb6ca643961670c46c15437dbc033bc23d28101935a69b3ad6caf786014d774de2342e2
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.0.8
-    SHA512 5a821aaaaa89027ce08a347e5fc216757c2971e29f7d24792609378c54f657839b3775bf639e7330b28b4f96ef0d32869f0a96afcb25c8a2e1c2fe51a6eb4aa3
+    REF openssl-3.1.0
+    SHA512 877b4bc4b59126bdaf626b01322c8ac5325945234acd14907e4a23019f1fd38ec17b5fae9ff60aa9b6b0089c29b0e4255a19cd2a1743c3db82a616286c60d3b9
     PATCHES
         ${MSVC_INTRINSIC_PATCH_PATH}
 )

--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -7,8 +7,6 @@ vcpkg_from_github(
     REPO openssl/openssl
     REF openssl-3.1.0
     SHA512 877b4bc4b59126bdaf626b01322c8ac5325945234acd14907e4a23019f1fd38ec17b5fae9ff60aa9b6b0089c29b0e4255a19cd2a1743c3db82a616286c60d3b9
-    PATCHES
-        ${MSVC_INTRINSIC_PATCH_PATH}
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.0.8",
+  "version-semver": "3.1.0",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -65,7 +65,7 @@
       "port-version": 0
     },
     "openssl3": {
-      "baseline": "3.0.8",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "ruy": {

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ffef86c25bec98d788c9e32a76d662f93ef7df0",
+      "git-tree": "105f3bdbb7857b8cd95b7043bbc56ef320a8cd9c",
       "version-semver": "3.1.0",
       "port-version": 0
     },

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ffef86c25bec98d788c9e32a76d662f93ef7df0",
+      "version-semver": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "22b17e34b1e1f274d1778efdd6637efe7a2897d5",
       "version-semver": "3.0.8",
       "port-version": 0


### PR DESCRIPTION

## Port Change

### Description

* https://github.com/openssl/openssl/releases/tag/openssl-3.1.0

### Triplet Support

All triplets for the registry

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl3"
            ],
            "baseline": "..."
        }
    ]
}
```
