### PR TITLE
[zlib-ng] update to 2.0.7

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/zlib-ng
-    REF 2.0.6
-    SHA512 4888f17160d0a87a9b349704047ae0d0dc57237a10e11adae09ace957afa9743cce5191db67cb082991421fc961ce68011199621034d2369c0e7724fad58b4c5
+    REF 2.0.7
+    SHA512 1c19a62bb00727ac49049c299fb70060da95b5fafa448144ae4133372ec8c3da15cef6c1303485290f269b23c580696554ca0383dba3e1f9609f65c332981988
     HEAD_REF master
 )
 
@@ -15,7 +15,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DZLIB_FULL_VERSION=2.0.6
         -DZLIB_ENABLE_TESTS=OFF
         -DWITH_NEW_STRATEGIES=ON
         -DWITH_NATIVE_INSTRUCTIONS=OFF # `-march=native` breaks `check_c_source_compiles`

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zlib-ng",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "zlib replacement with optimizations for 'next generation' systems",
   "homepage": "https://github.com/zlib-ng/zlib-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,7 +101,7 @@
       "port-version": 0
     },
     "zlib-ng": {
-      "baseline": "2.0.6",
+      "baseline": "2.0.7",
       "port-version": 0
     }
   }

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ef6900d01db2348cc5fab186ba0394f237f8a47",
+      "version": "2.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "1775e53af13daa53388baa410f0cd649d260a1da",
       "version": "2.0.6",
       "port-version": 0


### PR DESCRIPTION
## Port Change

### Description

* https://github.com/zlib-ng/zlib-ng/releases/tag/2.0.7

### Triplet Support

All supported triplets in the registry

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "zlib-ng"
            ],
            "baseline": "..."
        }
    ]
}
```
