### PR TITLE
[metal-cpp] update to latest

### DIFF
--- a/ports/metal-cpp/MetalCppConfig.cmake
+++ b/ports/metal-cpp/MetalCppConfig.cmake
@@ -84,8 +84,13 @@ The CMake module is wriiten by luncliff@gmail.com.
 You can do everything what you want with this file.
 
 #]===]
+if(MetalCpp_FOUND)
+    return()
+endif()
+set(MetalCpp_FOUND ON CACHE INTERNAL "Guard variable for 'MetalCppConfig.cmake'")
+
 cmake_minimum_required(VERSION 3.19)
-include(FindPackageHandleStandardArgs)
+find_package(PackageHandleStandardArgs REQUIRED)
 
 find_path(Foundation_INCLUDE_DIR "Foundation/Foundation.hpp" REQUIRED)
 find_library(Foundation_LIBRARY NAMES Foundation REQUIRED)

--- a/ports/metal-cpp/portfile.cmake
+++ b/ports/metal-cpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS12_iOS15.zip"
-    FILENAME metal-cpp_macOS12_iOS15.zip
-    SHA512 dabb4109c7bf283288b5b3bd392892a7a52ad13b4d53a72a117a852f54b0a82871bec3e55c8493d8048365839bd1be37d72f872041f43db314622bb4a983921f
+    URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13_iOS16.zip"
+    FILENAME metal-cpp_macOS13_iOS16.zip
+    SHA512 d35133f2b8829a28129a1662f8bf0f81df9a7937cd943abc948329fcade35b5258892cdf8b134cec0d9828cb0db67a708922eab0c2f64a8367c9bbf0382e043e
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/metal-cpp/vcpkg.json
+++ b/ports/metal-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-cpp",
-  "version-date": "2022-01-18",
+  "version-date": "2023-03-29",
   "description": "Metal-cpp is a low-overhead C++ interface for Metal that helps developers add Metal functionality to graphics apps, games, and game engines that are written in C++.",
   "homepage": "https://developer.apple.com/metal/cpp/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -49,7 +49,7 @@
       "port-version": 4
     },
     "metal-cpp": {
-      "baseline": "2022-01-18",
+      "baseline": "2023-03-29",
       "port-version": 0
     },
     "onnx": {

--- a/versions/m-/metal-cpp.json
+++ b/versions/m-/metal-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de9ad20ae174da5b95f9099ed3f8f1e238c0864c",
+      "version-date": "2023-03-29",
+      "port-version": 0
+    },
+    {
       "git-tree": "d801ec7527c3fbcbc9b3066b373ed71c78a8a5f8",
       "version-date": "2022-01-18",
       "port-version": 0


### PR DESCRIPTION

## Port Change

### Description

* https://developer.apple.com/metal/cpp/ macOS 13 / iOS 16

### Triplet Support

* `x64-osx`
* `arm64-osx`
* `arm64-ios`
* `arm64-ios-simulator`
* `x64-ios-simulator`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "metal-cpp"
            ],
            "baseline": "..."
        }
    ]
}
```
