### PR TITLE
[openssl3] update to 3.1.2

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.1.1
-    SHA512 7073fd82ce17a63d77babb6a184c14c7341e4b1f8f5a6caeaa1a6d9c78d6a12bb6d9cbad5d39d16412be6d1c12eac60364644664a8e26e3940476973ba07fd19
+    REF openssl-3.1.2
+    SHA512 c48ad86265b0fee18b23863b645a286d131a863a3418c7d2ed6c819eebb822ad0f2985ba3ecbf4def32515442f0eb40aba08f3146d113247e86ec80fbddca1c1
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.1.1",
+  "version-semver": "3.1.2",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -73,7 +73,7 @@
       "port-version": 0
     },
     "openssl3": {
-      "baseline": "3.1.1",
+      "baseline": "3.1.2",
       "port-version": 0
     },
     "ruy": {

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "069eb2441000b0dc121316929b979a7cbe18e979",
+      "version-semver": "3.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0534b39b5ce848f8840b9e6dce9fa9d0fc6f33e0",
       "version-semver": "3.1.1",
       "port-version": 0


### PR DESCRIPTION
### Changes

* `openssl3` references https://github.com/openssl/openssl/releases/tag/openssl-3.1.2
