### PR TITLE
[nsync] create a new port with 1.26.0

### DIFF
--- a/ports/nsync/export-targets.patch
+++ b/ports/nsync/export-targets.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 328f9b6..6a71b5b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,6 +41,9 @@ function (set_cpp_target tgtname files)
+ 			"${PROJECT_SOURCE_DIR}/platform/c++11.futex"
+ 		)
+ 	endif ()
++    
++    target_include_directories("${tgtname}" PUBLIC $<INSTALL_INTERFACE:include>)
++    
+ 
+ 	target_compile_definitions ("${tgtname}" PRIVATE "${NSYNC_CPP_DEFINITIONS}")
+ 
+@@ -399,14 +402,19 @@ endif ()
+ # By default, install nsync always
+ # set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+ 
+-install (TARGETS nsync
++install (TARGETS nsync EXPORT nsyncConfig
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development)
+ 
+-install (TARGETS nsync_cpp OPTIONAL
++install (TARGETS nsync_cpp OPTIONAL EXPORT nsyncConfig
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development)
+ 
++install(EXPORT nsyncConfig
++    NAMESPACE nsync::
++    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nsync
++)
++
+ set (NSYNC_INCLUDES
+ 	"public/nsync.h"
+ 	"public/nsync_atomic.h"

--- a/ports/nsync/fix-install.patch
+++ b/ports/nsync/fix-install.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b1f1dc..328f9b6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,7 +80,7 @@ set (NSYNC_OS_CPP_SRC
+ #    https://cmake.org/cmake/help/v3.1/policy/CMP0054.html
+ 
+ # Pick the include directory for the operating system.
+-if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
++if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX" OR "${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsStoreX")
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/win32")
+ 	set (NSYNC_CPP_FLAGS "/TP")
+ 
+@@ -230,7 +230,7 @@ elseif (("${CMAKE_SYSTEM_PROCESSOR}X" STREQUAL "ppc64X"))
+ endif ()
+ 
+ # Windows uses some include files from the posix directory also.
+-if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
++if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX" OR "${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsStoreX")
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/posix")
+ endif ()
+ 
+@@ -396,7 +396,8 @@ if (NSYNC_ENABLE_TESTS)
+ 	endforeach (t)
+ endif ()
+ 
+-set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
++# By default, install nsync always
++# set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+ 
+ install (TARGETS nsync
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -1,0 +1,27 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/nsync
+    REF 1.26.0
+    SHA512 8aa49997f100f161f0f32e99c9004ee845d7b16c1391e7eb62eea0897e2f91b7f9e5181055fdca637518751b6b26e16a1cd53e45adceda145285752c4b74f3bf
+    HEAD_REF master
+    PATCHES
+        fix-install.patch
+        export-targets.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DNSYNC_ENABLE_TESTS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME nsync CONFIG_PATH share/nsync)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nsync/vcpkg.json
+++ b/ports/nsync/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "nsync",
+  "version": "1.26.0",
+  "description": "nsync is a C library that exports various synchronization primitives, such as mutexes",
+  "homepage": "https://github.com/google/nsync",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -64,6 +64,10 @@
       "baseline": "0.3.0",
       "port-version": 0
     },
+    "nsync": {
+      "baseline": "1.26.0",
+      "port-version": 0
+    },
     "onnx": {
       "baseline": "1.12.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -60,6 +60,10 @@
       "baseline": "2023-04-05",
       "port-version": 0
     },
+    "nsync": {
+      "baseline": "1.26.0",
+      "port-version": 0
+    },
     "onnx": {
       "baseline": "1.12.0",
       "port-version": 0

--- a/versions/n-/nsync.json
+++ b/versions/n-/nsync.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "94bea01a643709904887893487309b35e962bbdd",
+      "version": "1.26.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create a new port for `find_package(nsync)`.
https://github.com/microsoft/vcpkg mainstream is using `unofficial::` namespace for the package.

### References

* https://github.com/google/nsync/releases/tag/1.26.0
* https://github.com/microsoft/vcpkg/pull/15714
* https://github.com/microsoft/vcpkg/pull/23811

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "nsync"
            ],
            "baseline": "..."
        }
    ]
}
```
