### PR TITLE
[farmhash] support `find_package(farmhash)`

### DIFF
--- a/ports/farmhash/portfile.cmake
+++ b/ports/farmhash/portfile.cmake
@@ -15,30 +15,15 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES ${WIN_PR_PATCH}
 )
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-# if((VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX) AND NOT ENV{CXX_FLAGS}) # This should be a compiler check
-#     set(ENV{CXXFLAGS} "-maes -msse4.2")
-# endif()
-# file(REMOVE_RECURSE "${SOURCE_PATH}/configure")
-# vcpkg_configure_make(
-#     AUTOCONFIG
-#     SOURCE_PATH ${SOURCE_PATH}
-# )
-# vcpkg_install_make()
-
-vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/${PORT})
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug/share"
-                    "${CURRENT_PACKAGES_DIR}/share" # eliminate unused files
 )
-file(INSTALL "${SOURCE_PATH}/COPYING"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-# file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/farmhashConfig.cmake" 
-#      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/farmhash/usage
+++ b/ports/farmhash/usage
@@ -1,4 +1,0 @@
-The package farmhash is compatible with built-in CMake targets:
-
-    FIND_PACKAGE(farmhash REQUIRED)
-    TARGET_LINK_LIBRARIES(main PRIVATE GOOGLE::farmhash) for linkage

--- a/ports/farmhash/vcpkg.json
+++ b/ports/farmhash/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "farmhash",
   "version-date": "2021-10-28",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FarmHash, a family of hash functions.",
   "homepage": "https://github.com/google/farmhash",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -30,7 +30,7 @@
     },
     "farmhash": {
       "baseline": "2021-10-28",
-      "port-version": 1
+      "port-version": 2
     },
     "fbgemm": {
       "baseline": "2022-04-09",

--- a/versions/f-/farmhash.json
+++ b/versions/f-/farmhash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57e539dd78c9884efb99bb2f2899973ab6226334",
+      "version-date": "2021-10-28",
+      "port-version": 2
+    },
+    {
       "git-tree": "c289fbc22fd771f99beed137d6bd60d9f5bc3463",
       "version-date": "2021-10-28",
       "port-version": 1


### PR DESCRIPTION
### Changes

No source changes.
Update portfile.cmake for later https://github.com/microsoft/vcpkg-tool versions.

### References

* https://github.com/google/farmhash 
* https://github.com/microsoft/vcpkg/pull/20506

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "farmhash"
            ],
            "baseline": "..."
        }
    ]
}
```
