### PR TITLE
[fft2d] Support `find_package(fft2d)`

### DIFF
--- a/ports/fft2d/CMakeLists.txt
+++ b/ports/fft2d/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(fft2d_alloc
   "${FFT2D_SOURCE_DIR}/alloc.c"
   "${FFT2D_SOURCE_DIR}/alloc.h"
 )
-target_include_directories(fft2d_alloc PUBLIC "${FFT2D_SOURCE_DIR}")
+target_include_directories(fft2d_alloc PRIVATE "${FFT2D_SOURCE_DIR}")
 
 # Requires implementation of fft2d_alloc.
 add_library(fft2d_fft4f2d "${FFT2D_SOURCE_DIR}/fft4f2d.c")
@@ -62,10 +62,15 @@ add_library(fft2d ALIAS fft2d_fftsg2d)
 
 include(GNUInstallDirs)
 install(TARGETS fft2d_alloc fft2d_fft4f2d fft2d_fftsg fft2d_fftsg2d fft2d_fftsg3d fft2d_shrtdct
+        EXPORT fft2d-config
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 install(FILES  ${FFT2D_SOURCE_DIR}/alloc.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fft2d
+)
+
+install(EXPORT fft2d-config
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/fft2d
 )

--- a/ports/fft2d/portfile.cmake
+++ b/ports/fft2d/portfile.cmake
@@ -6,12 +6,11 @@ vcpkg_from_github(
     REF v1.0
     SHA512 89c6e8fd57abf26351b3efb792008a1bbe62d404a4225dcae8aa666b3782a421be071bdc9760ebb0c95b5336ee5ea517d2fa43ab915045f7cf6fd76e73578079
 )
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/${PORT}")
 
 vcpkg_download_distfile(FFT2D_HEADER_1
     URLS "https://raw.githubusercontent.com/tensorflow/tensorflow/v2.7.0/third_party/fft2d/fft.h"
@@ -29,7 +28,7 @@ vcpkg_download_distfile(FFT2D_HEADER_2
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/fft2d/fft2d.h")
 file(INSTALL "${FFT2D_HEADER_2}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/fft2d" RENAME "fft2d.h")
 
-file(INSTALL ${SOURCE_PATH}/readme2d.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/readme.txt   DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/readme.txt"   DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/readme2d.txt")

--- a/ports/fft2d/vcpkg.json
+++ b/ports/fft2d/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fft2d",
   "version": "1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "General Purpose FFT (Fast Fourier/Cosine/Sine Transform) Package",
   "homepage": "http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -38,7 +38,7 @@
     },
     "fft2d": {
       "baseline": "1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "gemmlowp": {
       "baseline": "2022-02-09",

--- a/versions/f-/fft2d.json
+++ b/versions/f-/fft2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "884565836e16ac08a999176e42e4a13b5ac444ef",
+      "version": "1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "f231a59cd825d452d554e54af3cec98f0ec64487",
       "version": "1.0",
       "port-version": 2


### PR DESCRIPTION
### Changes

Update portfile.cmake.
Support `find_package(fft2d)`

### References

* https://github.com/petewarden/OouraFFT
* https://github.com/luncliff/vcpkg-registry/pull/105
* https://github.com/luncliff/vcpkg-registry/pull/46


### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "fft2d"
            ],
            "baseline": "..."
        }
    ]
}
```
