### PR TITLE
[zenny-atomic] update port for later vcpkg versions

### DIFF
--- a/ports/zenny-atomic/portfile.cmake
+++ b/ports/zenny-atomic/portfile.cmake
@@ -6,10 +6,10 @@ vcpkg_from_github(
     REF cce17a78911a43e9f963c31d172b2deee56f826e
     SHA512 db540b661ac42be33829f790f0d4a7084ece20ddec829b37fa2d4d2a6a15bead7a0b0475bb31b4cba9168224b3d0c2292f9dbf1fbf3a2d2a49e9466acb4c9387
 )
-file(COPY ${CURRENT_PORT_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CURRENT_PORT_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
-vcpkg_install_cmake()
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zenny-atomic/vcpkg.json
+++ b/ports/zenny-atomic/vcpkg.json
@@ -1,8 +1,15 @@
 {
   "name": "zenny-atomic",
   "version-date": "2021-10-15",
+  "port-version": 1,
   "description": "Simple <stdatomic.h>, <stdalign.h> and <threads.h> implementation for MSVC in Visual Studio 2019",
   "homepage": "https://github.com/zenny-chen/simple-stdatomic-for-VS-Clang",
   "license": "Apache-2.0",
-  "supports": "windows"
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -118,7 +118,7 @@
     },
     "zenny-atomic": {
       "baseline": "2021-10-15",
-      "port-version": 0
+      "port-version": 1
     },
     "zlib-ng": {
       "baseline": "2.0.7",

--- a/versions/z-/zenny-atomic.json
+++ b/versions/z-/zenny-atomic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0877339a1290d5eb58c75647015dbf309fd4bf88",
+      "version-date": "2021-10-15",
+      "port-version": 1
+    },
+    {
       "git-tree": "b6fcda91ac8276525056a95132c3563052b9532a",
       "version-date": "2021-10-15",
       "port-version": 0


### PR DESCRIPTION
### Changes

* use `vcpkg-cmake` host dependency
* use `vcpkg_install_copyright`

### References

* https://github.com/zenny-chen/simple-stdatomic-for-VS-Clang

### Triplet Support

* `x64-windows`
* `arm64-windows`
* `x64-uwp`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "zenny-atomic"
            ],
            "baseline": "..."
        }
    ]
}
```
