### PR TITLE
[openssl,openssl1,openssl3] Run `install_name_tool` for Apple dynamic triplet

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "openssl",
+  "version-semver": "3.1.3",
+  "description": "TLS/SSL and crypto library",
+  "homepage": "https://www.openssl.org/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "openssl3"
+  ]
+}

--- a/ports/openssl1/portfile.cmake
+++ b/ports/openssl1/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF OpenSSL_1_1_1u
-    SHA512 a3de3b6debfb0fcbc198271197755f11a8caae930c40165ad4601f82264570e47896a9dd11454504b003aa1c019c232f1fc58e3ba6006ae8dba4fd66e7f01023
+    REF OpenSSL_1_1_1w
+    SHA512 adfbcd5a1f3b80c15da608b7234a7bdc50afb1b98f8dc07b712c157058a01f21e1832fdbe1024a3ec7f5e335de3da003e5dccab044ec7510ad60b2b357529a3f
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -40,35 +40,35 @@ endif()
 include(${CMAKE_CURRENT_LIST_DIR}/detect_platform.cmake)
 
 # Clean & copy source files for working directories
-file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
-                    ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
+file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+                    "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
 )
-get_filename_component(SOURCE_DIR_NAME ${SOURCE_PATH} NAME)
-file(COPY        ${SOURCE_PATH}
-     DESTINATION ${CURRENT_BUILDTREES_DIR})
-file(RENAME      ${CURRENT_BUILDTREES_DIR}/${SOURCE_DIR_NAME}
-                 ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
-file(COPY        ${SOURCE_PATH}
-     DESTINATION ${CURRENT_BUILDTREES_DIR})
-file(RENAME      ${CURRENT_BUILDTREES_DIR}/${SOURCE_DIR_NAME}
-                 ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
+get_filename_component(SOURCE_DIR_NAME "${SOURCE_PATH}" NAME)
+file(COPY        "${SOURCE_PATH}"
+     DESTINATION "${CURRENT_BUILDTREES_DIR}")
+file(RENAME      "${CURRENT_BUILDTREES_DIR}/${SOURCE_DIR_NAME}"
+                 "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+file(COPY        "${SOURCE_PATH}"
+     DESTINATION "${CURRENT_BUILDTREES_DIR}")
+file(RENAME      "${CURRENT_BUILDTREES_DIR}/${SOURCE_DIR_NAME}"
+                 "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
 
 # see ${SOURCE_PATH}/NOTES-PERL.md
 vcpkg_find_acquire_program(PERL)
-get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
-vcpkg_add_to_path(${PERL_EXE_PATH})
+get_filename_component(PERL_EXE_PATH "${PERL}" DIRECTORY)
+vcpkg_add_to_path("${PERL_EXE_PATH}")
 
 if(NOT VCPKG_HOST_IS_WINDOWS)
     # see ${SOURCE_PATH}/NOTES-UNIX.md
     find_program(MAKE make REQUIRED)
-    get_filename_component(MAKE_EXE_PATH ${MAKE} DIRECTORY)
+    get_filename_component(MAKE_EXE_PATH "${MAKE}" DIRECTORY)
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     # see ${SOURCE_PATH}/NOTES-WINDOWS.md
     vcpkg_find_acquire_program(NASM)
-    get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
-    vcpkg_add_to_path(PREPEND ${NASM_EXE_PATH})
+    get_filename_component(NASM_EXE_PATH "${NASM}" DIRECTORY)
+    vcpkg_add_to_path(PREPEND "${NASM_EXE_PATH}")
     # note: jom is not for `vcpkg_add_to_path`
     vcpkg_find_acquire_program(JOM)
 
@@ -76,7 +76,7 @@ elseif(VCPKG_TARGET_IS_ANDROID)
     # see ${SOURCE_PATH}/NOTES-ANDROID.md
     if(NOT DEFINED ENV{ANDROID_NDK_ROOT} AND DEFINED ENV{ANDROID_NDK_HOME})
         message(STATUS "ENV{ANDROID_NDK_ROOT} will be set to $ENV{ANDROID_NDK_HOME}")
-        set(ENV{ANDROID_NDK_ROOT} $ENV{ANDROID_NDK_HOME})
+        set(ENV{ANDROID_NDK_ROOT} "$ENV{ANDROID_NDK_HOME}")
     endif()
     if(NOT DEFINED ENV{ANDROID_NDK_ROOT})
         message(FATAL_ERROR "ENV{ANDROID_NDK_ROOT} is required by ${SOURCE_PATH}/Configurations/15-android.conf")
@@ -90,8 +90,8 @@ elseif(VCPKG_TARGET_IS_ANDROID)
     else()
         message(FATAL_ERROR "Unknown NDK host platform")
     endif()
-    get_filename_component(NDK_TOOL_PATH $ENV{ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${NDK_HOST_TAG}/bin ABSOLUTE)
-    vcpkg_add_to_path(PREPEND ${NDK_TOOL_PATH})
+    get_filename_component(NDK_TOOL_PATH "$ENV{ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${NDK_HOST_TAG}/bin" ABSOLUTE)
+    vcpkg_add_to_path(PREPEND "${NDK_TOOL_PATH}")
 
 endif()
 
@@ -102,7 +102,7 @@ vcpkg_execute_required_process(
     COMMAND ${PERL} Configure ${OPENSSL_SHARED} ${CONFIGURE_OPTIONS} --debug
         ${PLATFORM}
         "--prefix=${CURRENT_PACKAGES_DIR}/debug"
-    WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
+    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
     LOGNAME "configure-perl-${TARGET_TRIPLET}-dbg"
 )
 message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
@@ -110,7 +110,7 @@ vcpkg_execute_required_process(
     COMMAND ${PERL} Configure ${OPENSSL_SHARED} ${CONFIGURE_OPTIONS}
         ${PLATFORM}
         "--prefix=${CURRENT_PACKAGES_DIR}"
-    WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
+    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
     LOGNAME "configure-perl-${TARGET_TRIPLET}-rel"
 )
 
@@ -118,13 +118,13 @@ if(VCPKG_TARGET_IS_UWP OR VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Building ${TARGET_TRIPLET}-dbg")
     vcpkg_execute_required_process(
         COMMAND ${JOM} /K /J ${VCPKG_CONCURRENCY} /F makefile install_dev
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
         LOGNAME "install-${TARGET_TRIPLET}-dbg"
     )
     message(STATUS "Building ${TARGET_TRIPLET}-rel")
     vcpkg_execute_required_process(
         COMMAND ${JOM} /K /J ${VCPKG_CONCURRENCY} /F makefile install_dev
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
         LOGNAME "install-${TARGET_TRIPLET}-rel"
     )
     vcpkg_copy_pdbs()
@@ -133,57 +133,93 @@ else()
     message(STATUS "Building ${TARGET_TRIPLET}-dbg")
     vcpkg_execute_required_process(
         COMMAND ${MAKE} -j ${VCPKG_CONCURRENCY} install_dev
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
         LOGNAME "install-${TARGET_TRIPLET}-dbg"
     )
     message(STATUS "Building ${TARGET_TRIPLET}-rel")
     vcpkg_execute_required_process(
         COMMAND ${MAKE} -j ${VCPKG_CONCURRENCY} install_dev
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
         LOGNAME "install-${TARGET_TRIPLET}-rel"
     )
     if(VCPKG_TARGET_IS_ANDROID AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         # install_dev copies symbolic link. overwrite them with the actual shared objects
-        file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libcrypto.so
-                     ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libssl.so
-             DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libcrypto.so"
+                     "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libssl.so"
+             DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
         )
-        file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libcrypto.so
-                     ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libssl.so
-             DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+        file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libcrypto.so"
+                     "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libssl.so"
+             DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
         )
     endif()
     # rename lib64 to lib for lib/pkgconfig
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib64)
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib64
-                    ${CURRENT_PACKAGES_DIR}/debug/lib)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib64")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib64" "${CURRENT_PACKAGES_DIR}/debug/lib")
     endif()
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib64)
-        file(RENAME ${CURRENT_PACKAGES_DIR}/lib64
-                    ${CURRENT_PACKAGES_DIR}/lib)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib64")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib64" "${CURRENT_PACKAGES_DIR}/lib")
     endif()
     vcpkg_fixup_pkgconfig()
 
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libcrypto.a
-                ${CURRENT_PACKAGES_DIR}/debug/lib/libssl.a
-                ${CURRENT_PACKAGES_DIR}/lib/libcrypto.a
-                ${CURRENT_PACKAGES_DIR}/lib/libssl.a
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/libcrypto.a"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/libssl.a"
+                "${CURRENT_PACKAGES_DIR}/lib/libcrypto.a"
+                "${CURRENT_PACKAGES_DIR}/lib/libssl.a"
     )
+    # see https://github.com/microsoft/vcpkg/issues/30805
+    if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+        find_program(INSTALL_NAME_TOOL install_name_tool
+            HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin/
+            REQUIRED
+        )
+        message(STATUS "Using install_name_tool: ${INSTALL_NAME_TOOL}")
+        # ${CURRENT_PACKAGES_DIR}/debug/lib -> @rpath
+        vcpkg_execute_build_process(
+            COMMAND "${INSTALL_NAME_TOOL}" -id "@rpath/libcrypto.3.dylib" "libcrypto.3.dylib"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib"
+            LOGNAME "fix-rpath-dbg"
+        )
+        vcpkg_execute_build_process(
+            COMMAND "${INSTALL_NAME_TOOL}" -change "${CURRENT_PACKAGES_DIR}/debug/lib/libcrypto.3.dylib" "@rpath/libcrypto.3.dylib" "libssl.3.dylib"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib"
+            LOGNAME "fix-rpath-dbg"
+        )
+        vcpkg_execute_build_process(
+            COMMAND "${INSTALL_NAME_TOOL}" -id "@rpath/libssl.3.dylib" "libssl.3.dylib"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib"
+            LOGNAME "fix-rpath-dbg"
+        )
+        # ${CURRENT_PACKAGES_DIR}/lib -> @rpath
+        vcpkg_execute_build_process(
+            COMMAND "${INSTALL_NAME_TOOL}" -id "@rpath/libcrypto.3.dylib" "libcrypto.3.dylib"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib"
+            LOGNAME "fix-rpath-rel"
+        )
+        vcpkg_execute_build_process(
+            COMMAND "${INSTALL_NAME_TOOL}" -change "${CURRENT_PACKAGES_DIR}/lib/libcrypto.3.dylib" "@rpath/libcrypto.3.dylib" "libssl.3.dylib"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib"
+            LOGNAME "fix-rpath-rel"
+        )
+        vcpkg_execute_build_process(
+            COMMAND "${INSTALL_NAME_TOOL}" -id "@rpath/libssl.3.dylib" "libssl.3.dylib"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib"
+            LOGNAME "fix-rpath-rel"
+        )
+    endif()
 else()
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin
-                        ${CURRENT_PACKAGES_DIR}/bin
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin"
+                        "${CURRENT_PACKAGES_DIR}/bin"
     )
     if(VCPKG_TARGET_IS_WINDOWS)
-        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/ossl_static.pdb
-                    ${CURRENT_PACKAGES_DIR}/lib/ossl_static.pdb
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/ossl_static.pdb"
+                    "${CURRENT_PACKAGES_DIR}/lib/ossl_static.pdb"
         )
     endif()
 endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL     ${SOURCE_PATH}/LICENSE
-     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
-)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/openssl1/vcpkg.json
+++ b/ports/openssl1/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl1",
-  "version-string": "1.1.1u",
+  "version-string": "1.1.1w",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0"

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl3",
   "version-semver": "3.1.3",
+  "port-version": 1,
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -85,7 +85,7 @@
       "port-version": 0
     },
     "openssl1": {
-      "baseline": "1.1.1u",
+      "baseline": "1.1.1w",
       "port-version": 0
     },
     "openssl3": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -80,6 +80,10 @@
       "baseline": "1.16.0",
       "port-version": 0
     },
+    "openssl": {
+      "baseline": "3.1.3",
+      "port-version": 0
+    },
     "openssl1": {
       "baseline": "1.1.1u",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -86,7 +86,7 @@
     },
     "openssl3": {
       "baseline": "3.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "pthreadpool": {
       "baseline": "2023-09-12",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2893bc9344f188be288514e424d342765a6b620d",
+      "version-semver": "3.1.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/o-/openssl1.json
+++ b/versions/o-/openssl1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d83810f33f08596a27de8d03e4d2ff3ea66e4bd2",
+      "version-string": "1.1.1w",
+      "port-version": 0
+    },
+    {
       "git-tree": "27cfab2fac8519fdb5ae699dfdd3a3c620fb3aa1",
       "version-string": "1.1.1u",
       "port-version": 0

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e70e09d10380632ea996bcc327bc4d79cf1b03b",
+      "version-semver": "3.1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "12873821eee945e8a5e59d43b13d29c6973109cf",
       "version-semver": "3.1.3",
       "port-version": 0


### PR DESCRIPTION
### Changes

Mac/iOS build requires `install_name_tool`

```
install_name_tool -id ... libcrypto.3.dylib
install_name_tool -change ... libcrypto.3.dylib
```

* Create an empty port `openssl` to `openssl3`
* Update `openssl1` to 1.1.1w

### References

* https://github.com/microsoft/vcpkg/issues/30805
* https://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1w

### Triplet Support

* `x64-osx`
* `arm64-osx`
* `arm64-ios`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl3",
                "openssl1",
                "openssl"
            ],
            "baseline": "..."
        }
    ]
}
```
