### PR TITLE
[xatlas] Create a new port

### DIFF
--- a/ports/xatlas/CMakeLists.txt
+++ b/ports/xatlas/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.13)
+project(xatlas LANGUAGES CXX)
+include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 11)
+
+list(APPEND headers xatlas/xatlas.h xatlas/xatlas_c.h)
+
+add_library(xatlas
+    ${headers}
+    xatlas/xatlas.cpp
+)
+
+set_target_properties(xatlas
+PROPERTIES
+    PUBLIC_HEADER "${headers}"
+)
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xatlas PRIVATE XATLAS_EXPORT_API=1)
+else()
+    target_compile_definitions(xatlas PRIVATE XATLAS_EXPORT_API=0)
+endif()
+
+install(TARGETS xatlas
+        EXPORT xatlas-config # minor trick to support `find_package(xatlas)`
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT xatlas-config
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/xatlas # share/xatlas
+)

--- a/ports/xatlas/portfile.cmake
+++ b/ports/xatlas/portfile.cmake
@@ -1,0 +1,23 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY) 
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jpcy/xatlas
+    REF f700c7790aaa030e794b52ba7791a05c085faf0c
+    SHA512 1f7afcc9056ab636abef017033aaf63d219cdec95e871beade2c694f8e8b4a58563cf506c5afb6d0d5536233f791e11adbcf3f6f26548105b31d381289892dea
+    HEAD_REF master
+)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}/source")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}/source")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/${PORT})
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xatlas/vcpkg.json
+++ b/ports/xatlas/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "xatlas",
+  "version-date": "2021-11-27",
+  "description": "Mesh parameterization / UV unwrapping library",
+  "homepage": "https://github.com/jpcy/xatlas",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/xatlas/vcpkg.json
+++ b/ports/xatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xatlas",
-  "version-date": "2021-11-27",
+  "version-date": "2023-11-07",
   "description": "Mesh parameterization / UV unwrapping library",
   "homepage": "https://github.com/jpcy/xatlas",
   "dependencies": [

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -29,6 +29,7 @@
       "name": "vcpkg-cmake",
       "host": true
     },
+    "xatlas",
     "zlib-ng"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -116,6 +116,10 @@
       "baseline": "2021-11-13",
       "port-version": 0
     },
+    "xatlas": {
+      "baseline": "2023-11-07",
+      "port-version": 0
+    },
     "xnnpack": {
       "baseline": "2023-04-13",
       "port-version": 0

--- a/versions/x-/xatlas.json
+++ b/versions/x-/xatlas.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e646b0e7caaf2a87b82e94132fca858f1ae73272",
+      "version-date": "2023-11-07",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create a new port. The projects were found at https://github.com/godotengine/godot/tree/4.1.2-stable/thirdparty#xatlas

### References

* https://github.com/jpcy/xatlas

### Triplet Support

* `x64-windows`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "xatlas"
            ],
            "baseline": "..."
        }
    ]
}
```
