### PR TITLE
[coreml-tools] More candidates for `site-packages` folder

### DIFF
--- a/ports/coreml-tools/portfile.cmake
+++ b/ports/coreml-tools/portfile.cmake
@@ -32,6 +32,8 @@ find_path(SITE_PACKAGES_DIR
     PATHS "${PYTHON_ROOT}/lib/python3.9/site-packages"
           "${PYTHON_ROOT}/lib/python3.10/site-packages"
           "${PYTHON_ROOT}/lib/python3.11/site-packages"
+          "${PYTHON_ROOT}/lib/python3.12/site-packages"
+          "${PYTHON_ROOT}/Lib/site-packages"
     REQUIRED
 )
 message(STATUS "  site-packages: ${SITE_PACKAGES_DIR}")

--- a/ports/coreml-tools/vcpkg.json
+++ b/ports/coreml-tools/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "coreml-tools",
   "version": "6.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "CPU INFOrmation library (x86/x86-64/ARM/ARM64, Linux/Windows/Android/macOS/iOS)",
   "homepage": "https://github.com/apple/coremltools",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -14,7 +14,7 @@
     },
     "coreml-tools": {
       "baseline": "6.1",
-      "port-version": 2
+      "port-version": 3
     },
     "cpuinfo": {
       "baseline": "2023-09-12",

--- a/versions/c-/coreml-tools.json
+++ b/versions/c-/coreml-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd52e153ea8b3fc2691fd49a8ab0315f2e5b89d2",
+      "version": "6.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "d29002eb2841d87dbd8fcdc5dca8e5472cf94b5e",
       "version": "6.1",
       "port-version": 2


### PR DESCRIPTION
### Changes

Additional path to guess `site-packages/` folder

### References

* https://github.com/apple/coremltools/releases

### Triplet Support

* `x64-osx`
* `arm64-osx`
* `arm64-ios`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "coreml-tools"
            ],
            "baseline": "..."
        }
    ]
}
```
