### PR TITLE
[onnxruntime] Fix CUDA build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,9 +15,9 @@ jobs:
       VCPKG_DOWNLOADS: "C:/vcpkg/downloads"
       VCPKG_DEFAULT_BINARY_CACHE: "C:/vcpkg/archives"
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
-      VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/triplets
+      VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: "create cache folders"
         run: |
           New-Item -Type Directory -Force ${env:VCPKG_DOWNLOADS}
@@ -40,3 +40,31 @@ jobs:
           runVcpkgFormatString: '[`install`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
+
+  cuda_x64:
+    runs-on: ["self-hosted", "Windows", "CUDA"]
+    continue-on-error: true
+    timeout-minutes: 60
+    env:
+      VCPKG_DOWNLOADS: "C:/vcpkg/downloads"
+      VCPKG_DEFAULT_BINARY_CACHE: "C:/vcpkg/archives"
+      VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
+      VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: "create cache folders"
+        run: |
+          New-Item -Type Directory -Force ${env:VCPKG_DOWNLOADS}
+          New-Item -Type Directory -Force ${env:VCPKG_DEFAULT_BINARY_CACHE}
+      - uses: microsoft/setup-msbuild@v1.1
+        with:
+          msbuild-architecture: x64
+      - uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: "C:/vcpkg"
+          vcpkgGitCommitId: "a42af01b72c28a8e1d7b48107b33e4f286a55ef6" # 2023.11.20
+          vcpkgJsonGlob: "test/vcpkg.json"
+          runVcpkgInstall: true
+          runVcpkgFormatString: '[`install`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
+        env:
+          VCPKG_DEFAULT_TRIPLET: "x64-windows"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: microsoft/setup-msbuild@v1.1
         with:
           msbuild-architecture: x64
-      - uses: lukka/run-vcpkg@v11
+      - uses: lukka/run-vcpkg@v11.3
         with:
           vcpkgDirectory: "C:/vcpkg"
           vcpkgGitCommitId: "a42af01b72c28a8e1d7b48107b33e4f286a55ef6" # 2023.11.20
@@ -56,10 +56,11 @@ jobs:
         run: |
           New-Item -Type Directory -Force ${env:VCPKG_DOWNLOADS}
           New-Item -Type Directory -Force ${env:VCPKG_DEFAULT_BINARY_CACHE}
+          Move-Item -Path "test/self-hosted-cuda.json" -Destination "test/vcpkg.json" -Force
       - uses: microsoft/setup-msbuild@v1.1
         with:
           msbuild-architecture: x64
-      - uses: lukka/run-vcpkg@v11
+      - uses: lukka/run-vcpkg@v11.3
         with:
           vcpkgDirectory: "C:/vcpkg"
           vcpkgGitCommitId: "a42af01b72c28a8e1d7b48107b33e4f286a55ef6" # 2023.11.20
@@ -68,3 +69,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
+
+      - uses: yumis-coconudge/clean-workspace-action@v1
+        with:
+          additional-path: "C:/vcpkg/installed"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,9 +75,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-mac-host"'
+              key: '"v2349-bin-mac-host"'
               restoreKeys: |
-                "v2348-bin-mac-host"
+                "v2349-bin-mac-host"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             displayName: "coreml-tools"
@@ -124,15 +124,15 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: Cache@2
             inputs:
-              key: '"v2348-down-windows"'
+              key: '"v2349-down-windows"'
               restoreKeys: |
-                "v2348-down-windows"
+                "v2349-down-windows"
               path: $(Build.BinariesDirectory)/vcpkg/downloads
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-windows" | "$(vcpkg.default.triplet)"'
+              key: '"v2349-bin-windows" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2348-bin-windows" | "$(vcpkg.default.triplet)"
+                "v2349-bin-windows" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             displayName: "libdispatch"
@@ -182,15 +182,15 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: Cache@2
             inputs:
-              key: '"v2348-down-uwp"'
+              key: '"v2349-down-uwp"'
               restoreKeys: |
-                "v2348-down-uwp"
+                "v2349-down-uwp"
               path: $(Build.BinariesDirectory)/vcpkg/downloads
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-uwp" | "$(vcpkg.default.triplet)"'
+              key: '"v2349-bin-uwp" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2348-bin-uwp" | "$(vcpkg.default.triplet)"
+                "v2349-bin-uwp" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             displayName: "libdispatch"
@@ -245,15 +245,15 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: Cache@2
             inputs:
-              key: '"v2348-down-ubuntu"'
+              key: '"v2349-down-ubuntu"'
               restoreKeys: |
-                "v2348-down-ubuntu"
+                "v2349-down-ubuntu"
               path: $(Build.BinariesDirectory)/vcpkg/downloads
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"'
+              key: '"v2349-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"'
               restoreKeys: |
-                "v2348-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"
+                "v2349-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             displayName: "tensorflow-lite"
@@ -303,15 +303,15 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: Cache@2
             inputs:
-              key: '"v2348-down-android"'
+              key: '"v2349-down-android"'
               restoreKeys: |
-                "v2348-down-android"
+                "v2349-down-android"
               path: $(Build.BinariesDirectory)/vcpkg/downloads
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-android" | "$(vcpkg.default.triplet)"'
+              key: '"v2349-bin-android" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2348-bin-android" | "$(vcpkg.default.triplet)"
+                "v2349-bin-android" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             inputs:
@@ -365,15 +365,15 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: Cache@2
             inputs:
-              key: '"v2348-down-apple"'
+              key: '"v2349-down-apple"'
               restoreKeys: |
-                "v2348-down-apple"
+                "v2349-down-apple"
               path: $(Build.BinariesDirectory)/vcpkg/downloads
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-osx" | "$(vcpkg.default.triplet)"'
+              key: '"v2349-bin-osx" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2348-bin-osx" | "$(vcpkg.default.triplet)"
+                "v2349-bin-osx" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             inputs:
@@ -425,15 +425,15 @@ stages:
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: Cache@2
             inputs:
-              key: '"v2348-down-apple"'
+              key: '"v2349-down-apple"'
               restoreKeys: |
-                "v2348-down-apple"
+                "v2349-down-apple"
               path: $(Build.BinariesDirectory)/vcpkg/downloads
           - task: Cache@2
             inputs:
-              key: '"v2348-bin-ios" | "$(vcpkg.default.triplet)"'
+              key: '"v2349-bin-ios" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2348-bin-ios" | "$(vcpkg.default.triplet)"
+                "v2349-bin-ios" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             displayName: "arm64-ios"

--- a/ports/onnxruntime/fix-cuda.patch
+++ b/ports/onnxruntime/fix-cuda.patch
@@ -32,3 +32,16 @@ index 8cf6dd1..0119493 100644
      endif()
      if (MSVC)
        foreach(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORY ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index d3e9c36..3a4d34c 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -1039,7 +1039,7 @@ function(onnxruntime_add_shared_library_module target_name)
+     add_library(${target_name} SHARED ${ARGN})
+   else()
+     #On Windows, this target shouldn't generate an import lib, but I don't know how to disable it.
+-    add_library(${target_name} MODULE ${ARGN})
++    add_library(${target_name} SHARED ${ARGN})
+   endif()
+ 
+   onnxruntime_configure_target(${target_name})

--- a/ports/onnxruntime/fix-cuda.patch
+++ b/ports/onnxruntime/fix-cuda.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index 8cf6dd1..0119493 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -663,6 +663,8 @@ set(ORT_PROVIDER_FLAGS)
+ set(ORT_PROVIDER_CMAKE_FLAGS)
+ 
+ if (onnxruntime_USE_CUDA)
++  include(CheckLanguage)
++  check_language(CUDA)
+   enable_language(CUDA)
+   message( STATUS "CMAKE_CUDA_COMPILER_VERSION: ${CMAKE_CUDA_COMPILER_VERSION}")
+ 
+@@ -863,9 +865,20 @@ function(onnxruntime_set_compile_flags target_name)
+     endif()
+     set_target_properties(${target_name} PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
+     if (onnxruntime_USE_CUDA)
++      include(CheckLanguage)
++      check_language(CUDA)
++      find_package(CUDAToolkit REQUIRED)
+       # Suppress a "conversion_function_not_usable" warning in gsl/span
+       target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe \"--diag_suppress=conversion_function_not_usable\">")
+       target_compile_definitions(${target_name} PRIVATE -DDISABLE_CUSPARSE_DEPRECATED)
++      if(${target_name} MATCHES "cuda")
++        find_path(CUDAToolkit_CUPTI_INCLUDE_DIR NAMES cupti.h PATHS ${CUDAToolkit_INCLUDE_DIRS} "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/include" REQUIRED)
++        find_library(CUDAToolkit_CUPTI_LIBRARY NAMES cupti PATHS ${CUDAToolkit_LIBRARY_DIR} "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/lib64" REQUIRED)
++        get_filename_component(CUDAToolkit_CUPTI_LIBRARY_DIR "${CUDAToolkit_CUPTI_LIBRARY}" PATH)
++        target_include_directories(${target_name} PRIVATE ${CUDAToolkit_CUPTI_INCLUDE_DIR})
++        target_link_libraries(${target_name} PRIVATE ${CUDAToolkit_CUPTI_LIBRARY})
++        target_link_directories(${target_name} PRIVATE ${CUDAToolkit_CUPTI_LIBRARY_DIR})
++      endif()
+     endif()
+     if (MSVC)
+       foreach(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORY ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -65,7 +65,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
-    set(GENERATOR_OPTIONS WINDOWS_USE_MSBUILD)
+    # For some reason CUDA compiler detection is not working in WINDOWS_USE_MSBUILD
+    # set(GENERATOR_OPTIONS WINDOWS_USE_MSBUILD)
 elseif(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
     set(GENERATOR_OPTIONS GENERATOR Xcode)
 else()
@@ -103,6 +104,10 @@ else()
 endif()
 message(STATUS "Using python3: ${PYTHON3}")
 vcpkg_add_to_path(PREPEND "${PYTHON_PATH}")
+
+if("cuda" IN_LIST FEATURES)
+    message(STATUS "Using CUDA: $ENV{CUDA_PATH}")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/cmake"

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake.patch
         fix-source-flatbuffers.patch
+        fix-cuda.patch
 )
 
 find_program(PROTOC NAMES protoc
@@ -62,6 +63,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         framework onnxruntime_BUILD_OBJC
     INVERTED_FEATURES
         abseil   onnxruntime_DISABLE_ABSEIL
+        cuda     onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION
 )
 
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
@@ -106,7 +108,14 @@ message(STATUS "Using python3: ${PYTHON3}")
 vcpkg_add_to_path(PREPEND "${PYTHON_PATH}")
 
 if("cuda" IN_LIST FEATURES)
+    # https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html
+    if(NOT DEFINED ENV{CUDA_PATH})
+        message(FATAL_ERROR "ENV{CUDA_PATH} is required. Please check the environment variable")
+    endif()
     message(STATUS "Using CUDA: $ENV{CUDA_PATH}")
+    get_filename_component(CUDA_VERSION "$ENV{CUDA_PATH}" NAME)
+    string(REPLACE "v" "" CUDA_VERSION "${CUDA_VERSION}") # "v12.0" -> "12.0"
+    message(STATUS "  version: ${CUDA_VERSION}")
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onnxruntime",
   "version-semver": "1.16.0",
+  "port-version": 1,
   "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
   "homepage": "https://www.onnxruntime.ai",
   "dependencies": [

--- a/test/self-hosted-cuda.json
+++ b/test/self-hosted-cuda.json
@@ -9,13 +9,15 @@
       "name": "onnxruntime",
       "features": [
         "cuda"
-      ]
+      ],
+      "platform": "x64 & windows"
     },
     {
       "name": "opencv4",
       "features": [
         "cudnn"
-      ]
+      ],
+      "platform": "x64 & windows"
     }
   ]
 }

--- a/test/self-hosted-cuda.json
+++ b/test/self-hosted-cuda.json
@@ -1,0 +1,21 @@
+{
+  "name": "test",
+  "version-date": "2023-12-09",
+  "description": "vcpkg registry maintained by @luncliff",
+  "homepage": "https://github.com/luncliff/vcpkg-registry",
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "onnxruntime",
+      "features": [
+        "cuda"
+      ]
+    },
+    {
+      "name": "opencv4",
+      "features": [
+        "cudnn"
+      ]
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -82,7 +82,7 @@
     },
     "onnxruntime": {
       "baseline": "1.16.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openssl": {
       "baseline": "3.1.3",

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12e70855156d3ce75ba8655971f41cc94e2b0449",
+      "version-semver": "1.16.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "01b085df61589562b3cc8d14cc36c2c21cb2cd27",
       "version-semver": "1.16.0",
       "port-version": 0

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12e70855156d3ce75ba8655971f41cc94e2b0449",
+      "git-tree": "e9046291855178e0aebf9728e65f233a5507c3c0",
       "version-semver": "1.16.0",
       "port-version": 1
     },


### PR DESCRIPTION
### Changes

Fix #136 

Tested with CUDA Toolkit 12.3.  
For some reason, MSBuild projects can't detect CUDA toolkit paths and NVCC outputs.  
Tried to provide `CMAKE_VS_PLATFORM_TOOLSET_CUDA` and some variables but they didn't either.

* Use the default CMake generator option(Ninja) in configure `vcpkg_cmake_configure`. 
* Patch `fix-cuda.patch` to add path information for CUPTI library which is installed under `"${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/"`

Print more messages in portfile.cmake

### References

* https://cmake.org/cmake/help/latest/variable/CMAKE_VS_PLATFORM_TOOLSET_CUDA.html
* #136 

### Triplet Support

* `x64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "onnxruntime"
            ],
            "baseline": "..."
        }
    ]
}
```
