### PR TITLE
[fbgemm] update to v0.5.0

### DIFF
--- a/ports/fbgemm/fix-cmakelists.patch
+++ b/ports/fbgemm/fix-cmakelists.patch
@@ -1,47 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6f19a16..3c758d2 100644
+index ab980eb..218ec02 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -6,7 +6,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
- include(GNUInstallDirs)
- 
- # function to extract filelists from defs.bzl file
--find_package(PythonInterp)
- function(get_filelist name outputvar)
-   execute_process(
-     COMMAND "${PYTHON_EXECUTABLE}" -c
-@@ -19,9 +18,6 @@ endfunction()
- 
- project(fbgemm VERSION 0.1 LANGUAGES CXX C)
- 
--set(FBGEMM_LIBRARY_TYPE "default" CACHE STRING
--  "Type of library (shared, static, or default) to build")
--set_property(CACHE FBGEMM_LIBRARY_TYPE PROPERTY STRINGS default static shared)
- option(FBGEMM_BUILD_TESTS "Build fbgemm unit tests" ON)
- option(FBGEMM_BUILD_BENCHMARKS "Build fbgemm benchmarks" ON)
- option(FBGEMM_BUILD_DOCS "Build fbgemm documentation" OFF)
-@@ -101,18 +97,11 @@ set_target_properties(fbgemm_generic fbgemm_avx2 fbgemm_avx512 PROPERTIES
- #2) MSVC uses /MD in default cxx compiling flags,
- #need to change it to /MT in static case
- if(MSVC)
--  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4267 /wd4305 /wd4309")
--  if(FBGEMM_LIBRARY_TYPE STREQUAL "static")
-+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4267 /wd4305 /wd4309 /wd4703 /bigobj")
-+  if(NOT BUILD_SHARED_LIBS)
-     target_compile_definitions(fbgemm_generic PRIVATE ASMJIT_STATIC)
-     target_compile_definitions(fbgemm_avx2 PRIVATE ASMJIT_STATIC)
-     target_compile_definitions(fbgemm_avx512 PRIVATE ASMJIT_STATIC)
--    foreach(flag_var
--      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
--      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
--      if(${flag_var} MATCHES "/MD")
--        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
--      endif(${flag_var} MATCHES "/MD")
--    endforeach(flag_var)
+@@ -178,6 +178,7 @@ if(MSVC)
+       endif(${flag_var} MATCHES "/MD")
+     endforeach(flag_var)
    endif()
++  target_compile_options(fbgemm_generic PRIVATE /bigobj)
    target_compile_options(fbgemm_avx2 PRIVATE "/arch:AVX2")
    target_compile_options(fbgemm_avx512 PRIVATE "/arch:AVX512")
-@@ -145,7 +134,8 @@ message(WARNING "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
+ else(MSVC)
+@@ -229,7 +230,8 @@ message(WARNING "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
  message(WARNING "CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
  message(WARNING "==========")
  
@@ -51,8 +20,8 @@ index 6f19a16..3c758d2 100644
    #Download asmjit from github if ASMJIT_SRC_DIR is not specified.
    if(NOT DEFINED ASMJIT_SRC_DIR)
      set(ASMJIT_SRC_DIR "${FBGEMM_SOURCE_DIR}/third_party/asmjit"
-@@ -164,7 +154,8 @@ if(NOT TARGET asmjit)
-   set_property(TARGET asmjit PROPERTY POSITION_INDEPENDENT_CODE ON)
+@@ -258,7 +260,8 @@ if(NOT TARGET asmjit)
+   endif()
  endif()
  
 -if(NOT TARGET cpuinfo)
@@ -61,14 +30,14 @@ index 6f19a16..3c758d2 100644
    #Download cpuinfo from github if CPUINFO_SOURCE_DIR is not specified.
    if(NOT DEFINED CPUINFO_SOURCE_DIR)
      set(CPUINFO_SOURCE_DIR "${FBGEMM_SOURCE_DIR}/third_party/cpuinfo"
-@@ -185,49 +176,38 @@ endif()
+@@ -279,20 +282,20 @@ endif()
  target_include_directories(fbgemm_generic BEFORE
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
 -      PRIVATE "${ASMJIT_SRC_DIR}/src"
 -      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
 +)
-+target_link_libraries(fbgemm_generic PUBLIC asmjit::asmjit cpuinfo::cpuinfo)
++target_link_libraries(fbgemm_generic PRIVATE asmjit::asmjit cpuinfo::cpuinfo)
  
  target_include_directories(fbgemm_avx2 BEFORE
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
@@ -76,71 +45,43 @@ index 6f19a16..3c758d2 100644
 -      PRIVATE "${ASMJIT_SRC_DIR}/src"
 -      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
 +)
-+target_link_libraries(fbgemm_avx2 PUBLIC asmjit::asmjit cpuinfo::cpuinfo)
++target_link_libraries(fbgemm_avx2 PRIVATE asmjit::asmjit cpuinfo::cpuinfo)
  
  target_include_directories(fbgemm_avx512 BEFORE
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
 -      PRIVATE "${ASMJIT_SRC_DIR}/src"
 -      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
--
--if(FBGEMM_LIBRARY_TYPE STREQUAL "default")
--  add_library(fbgemm
--    $<TARGET_OBJECTS:fbgemm_generic>
--    $<TARGET_OBJECTS:fbgemm_avx2>
--    $<TARGET_OBJECTS:fbgemm_avx512>)
--elseif(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
--  add_library(fbgemm SHARED
--    $<TARGET_OBJECTS:fbgemm_generic>
--    $<TARGET_OBJECTS:fbgemm_avx2>
--    $<TARGET_OBJECTS:fbgemm_avx512>)
 +)
-+target_link_libraries(fbgemm_avx512 PUBLIC asmjit::asmjit cpuinfo::cpuinfo)
-+
-+add_library(fbgemm
-+  $<TARGET_OBJECTS:fbgemm_generic>
-+  $<TARGET_OBJECTS:fbgemm_avx2>
-+  $<TARGET_OBJECTS:fbgemm_avx512>)
-+if(BUILD_SHARED_LIBS)
-   set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
-   set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
-   set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
-   set_target_properties(fbgemm PROPERTIES
-     CXX_VISIBILITY_PRESET hidden)
--elseif(FBGEMM_LIBRARY_TYPE STREQUAL "static")
--  add_library(fbgemm STATIC
--    $<TARGET_OBJECTS:fbgemm_generic>
--    $<TARGET_OBJECTS:fbgemm_avx2>
--    $<TARGET_OBJECTS:fbgemm_avx512>)
-+else()
-   #MSVC need to define FBGEMM_STATIC for fbgemm_generic also to
-   #avoid generating _dllimport functions.
-   target_compile_definitions(fbgemm_generic PRIVATE FBGEMM_STATIC)
-   target_compile_definitions(fbgemm_avx2 PRIVATE FBGEMM_STATIC)
-   target_compile_definitions(fbgemm_avx512 PRIVATE FBGEMM_STATIC)
-   target_compile_definitions(fbgemm PRIVATE FBGEMM_STATIC)
--else()
--  message(FATAL_ERROR "Unsupported library type ${FBGEMM_LIBRARY_TYPE}")
- endif()
++target_link_libraries(fbgemm_avx512 PRIVATE asmjit::asmjit cpuinfo::cpuinfo)
  
- if(USE_SANITIZER)
-@@ -239,9 +219,7 @@ target_include_directories(fbgemm BEFORE
-     PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
+ if(FBGEMM_LIBRARY_TYPE STREQUAL "default")
+   add_library(fbgemm
+@@ -332,11 +335,9 @@ target_include_directories(fbgemm BEFORE
      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>)
  
--target_link_libraries(fbgemm $<BUILD_INTERFACE:asmjit>
+ target_link_libraries(fbgemm
+-  $<BUILD_INTERFACE:asmjit>
 -  $<BUILD_INTERFACE:cpuinfo>)
--add_dependencies(fbgemm asmjit cpuinfo)
-+target_link_libraries(fbgemm PUBLIC asmjit::asmjit cpuinfo::cpuinfo)
+-add_dependencies(fbgemm
+-  asmjit
+-  cpuinfo)
++  asmjit::asmjit
++  cpuinfo::cpuinfo
++)
  
- install(TARGETS fbgemm EXPORT fbgemmLibraryConfig
-   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-@@ -254,7 +232,7 @@ install(FILES ${FBGEMM_PUBLIC_HEADERS}
- install(EXPORT fbgemmLibraryConfig DESTINATION share/cmake/fbgemm
-   FILE fbgemmLibraryConfig.cmake)
- 
--if(MSVC)
-+if(FALSE)
+ if(OpenMP_FOUND)
+   target_link_libraries(fbgemm OpenMP::OpenMP_CXX)
+@@ -361,11 +362,9 @@ install(
+ if(MSVC)
    if(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
      install(
-       FILES $<TARGET_PDB_FILE:fbgemm> $<TARGET_PDB_FILE:asmjit>
+-      FILES $<TARGET_PDB_FILE:fbgemm> $<TARGET_PDB_FILE:asmjit>
++      FILES $<TARGET_PDB_FILE:fbgemm>
+       DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
+   endif()
+-  install(TARGETS fbgemm DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  install(TARGETS asmjit DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
+ #Make project importable from the build directory

--- a/ports/fbgemm/portfile.cmake
+++ b/ports/fbgemm/portfile.cmake
@@ -4,26 +4,41 @@ vcpkg_find_acquire_program(PYTHON3)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pytorch/fbgemm
-    REF 8ed5c4e3fc1a704e57d642f8d217facd9e96af30
-    SHA512 3213947606068ddf11c2be2e4230b8925c5fb3b4442b644ed46e3dc1df4a8642a006fa9a6a2d6e4d03787a35e7717ef0fdeae1e27ffbb99ea80be79f1fbe6ead
+    REF v0.5.0
+    SHA512 b200a174b493cf2540ca993f42405ed9c7af00a56788af3b5e1a3c1b1a27fb0f3b2189f809c6e7a8322e39e56fe74f249e4e93aa672d643df83b0e8d55339c35
     PATCHES
         fix-cmakelists.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        gpu FBGEMM_BUILD_FBGEMM_GPU
+    INVERTED_FEATURES
+        gpu FBGEMM_CPU_ONLY
+        gpu USE_ROCM
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DUSE_SANITIZER=OFF
         -DFBGEMM_BUILD_TESTS=OFF
         -DFBGEMM_BUILD_BENCHMARKS=OFF
+        -DFBGEMM_BUILD_DOCS=OFF
+        -DFBGEMM_LIBRARY_TYPE:STRING="default"
         -DPYTHON_EXECUTABLE=${PYTHON3} # inject the path instead of find_package(Python)
+    MAYBE_UNUSED_VARIABLES
+        FBGEMM_CPU_ONLY
+        USE_ROCM
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME fbgemmLibrary CONFIG_PATH share/cmake/${PORT})
+vcpkg_cmake_config_fixup(PACKAGE_NAME fbgemmLibrary CONFIG_PATH "share/cmake/${PORT}")
 
 # this internal header is required by pytorch
 file(INSTALL     "${SOURCE_PATH}/src/RefImplementations.h"
      DESTINATION "${CURRENT_PACKAGES_DIR}/include/fbgemm/src")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fbgemm/vcpkg.json
+++ b/ports/fbgemm/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "fbgemm",
-  "version-date": "2022-04-09",
+  "version-semver": "0.5.0",
   "description": "FB (Facebook) + GEMM (General Matrix-Matrix Multiplication)",
-  "homepage": "https://code.fb.com/ml-applications/fbgemm/",
+  "homepage": "https://github.com/pytorch/FBGEMM",
   "supports": "!(x86 | uwp)",
   "dependencies": [
     "asmjit",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -37,7 +37,7 @@
       "port-version": 2
     },
     "fbgemm": {
-      "baseline": "2022-04-09",
+      "baseline": "0.5.0",
       "port-version": 0
     },
     "fft2d": {

--- a/versions/f-/fbgemm.json
+++ b/versions/f-/fbgemm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a07d9f3c6118b2cf370278cfb4d5f164be7b0ba0",
+      "version-semver": "0.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8b638d76e708d744490f8980eb0acaaa721d363d",
       "version-date": "2022-04-09",
       "port-version": 0


### PR DESCRIPTION
### Changes

Update the FBGEMM version

#### Concerns

Supporting FBGEMM_GPU with another port or as a feature.

### References

* https://github.com/pytorch/FBGEMM/releases/tag/v0.5.0

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`
* `arm64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "fbgemm"
            ],
            "baseline": "..."
        }
    ]
}
```
