### PR TITLE
[tensorpipe] update to 2022-05-14

### DIFF
--- a/ports/tensorpipe/fix-cmakelists.patch
+++ b/ports/tensorpipe/fix-cmakelists.patch
@@ -25,8 +25,8 @@ index 5c36064..cfaf0bc 100644
 -find_package(uv REQUIRED)
 -list(APPEND TP_LINK_LIBRARIES uv::uv)
 +# `libuv` in vcpkg
-+find_package(unofficial-libuv CONFIG REQUIRED) 
-+list(APPEND TP_LINK_LIBRARIES unofficial::libuv::libuv)
++find_package(libuv CONFIG REQUIRED) 
++list(APPEND TP_LINK_LIBRARIES libuv::uv)
  
  ### shm
  

--- a/ports/tensorpipe/portfile.cmake
+++ b/ports/tensorpipe/portfile.cmake
@@ -1,11 +1,10 @@
-vcpkg_fail_port_install(ON_TARGET "windows" "uwp")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pytorch/tensorpipe
-    REF d2aa3485e8229c98891dfd604b514a39d45a5c99
-    SHA512 fbefc18792458ac2234045df8e3cce8dbb17a5e719258f020c2c1d388092358bd2562e53a0377ca18f40bcfbeae4367c277a74c31c5e45296b891453a962e460
+    REF bb1473a4b38b18268e8693044afdb8635bc8351b
+    SHA512 cf0334f81affb2d844bc8b63c533a749753e36ee096f841641716a3bf044b17580262a2e9056d8d1351228e323c4f75401a2a120a5de397e80ec21a33fe56d2b
     PATCHES
         fix-cmakelists.patch
 )

--- a/ports/tensorpipe/vcpkg.json
+++ b/ports/tensorpipe/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorpipe",
-  "version-date": "2021-11-13",
+  "version-date": "2022-05-14",
   "description": "A tensor-aware point-to-point communication primitive for machine learning",
   "homepage": "https://github.com/pytorch/tensorpipe",
   "supports": "linux | osx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -125,7 +125,7 @@
       "port-version": 0
     },
     "tensorpipe": {
-      "baseline": "2021-11-13",
+      "baseline": "2022-05-14",
       "port-version": 0
     },
     "xatlas": {

--- a/versions/t-/tensorpipe.json
+++ b/versions/t-/tensorpipe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2db63d9b007bc20c99bd76d48c2ccf80f6bc4a6a",
+      "version-date": "2022-05-14",
+      "port-version": 0
+    },
+    {
       "git-tree": "14ebb3414800613d2d63c4bff9791e4892beced3",
       "version-date": "2021-11-13",
       "port-version": 0


### PR DESCRIPTION
### Changes

The repository is archived.

### References

* https://github.com/pytorch/tensorpipe

### Triplet Support

* `x64-linux`
* `x64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "tensorpipe"
            ],
            "baseline": "..."
        }
    ]
}
```
