### PR TITLE
[onnx] update to 1.15.0

### DIFF
--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onnx/onnx
-    REF v1.14.1
-    SHA512 f846fffb286c4aeadc01462f220515f0a5c2ce1cbec849da7092a08c2676f8308af7315318a2866e9182f9aed719984ef95a9ddc69ffe0e62e40664395df5efd
+    REF v1.15.0
+    SHA512 b46a4ab70af88053318eba45251c1f71528f15e45a33042877570e8d857febd3ec66e2e811fcda2105a4f17b84c9a1c6a0aaa22756c3287321b3ea29e83127fd
     PATCHES
         fix-cmakelists.patch
 )
@@ -77,7 +77,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX PACKAGE_NAME ONNX)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
@@ -99,6 +99,8 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/include/onnx/defs/sequence"
     "${CURRENT_PACKAGES_DIR}/include/onnx/defs/traditionalml"
     "${CURRENT_PACKAGES_DIR}/include/onnx/defs/training"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/image"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/defs/text"
     "${CURRENT_PACKAGES_DIR}/include/onnx/examples"
     "${CURRENT_PACKAGES_DIR}/include/onnx/frontend"
     "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_cpp2py_export"

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "onnx",
-  "version-semver": "1.14.1",
-  "port-version": 2,
+  "version-semver": "1.15.0",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -77,8 +77,8 @@
       "port-version": 0
     },
     "onnx": {
-      "baseline": "1.14.1",
-      "port-version": 2
+      "baseline": "1.15.0",
+      "port-version": 0
     },
     "onnxruntime": {
       "baseline": "1.16.0",

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18fa90d742ae729066d99e418a07a4a8f00e34be",
+      "version-semver": "1.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cd5846d14598c277b59388adfb2977a99cbea292",
       "version-semver": "1.14.1",
       "port-version": 2


### PR DESCRIPTION
### Changes

Update to later version

### References

* https://github.com/onnx/onnx/releases/tag/v1.15.0
* #116
* #141

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "onnx"
            ],
            "baseline": "..."
        }
    ]
}
```
