### PR TITLE
[dlpack] Create a new port with v0.8

### DIFF
--- a/ports/dlpack/portfile.cmake
+++ b/ports/dlpack/portfile.cmake
@@ -1,0 +1,26 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/dlpack
+    REF v0.8
+    SHA512 1669d5145904918499682ed80db7a444d012708c7b8c1d03410ef8fa8bcacd95e56450e95a842b0b4d900f973d04e24bd86e33f54b8afe80dd5dbbb02d04fc13
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_MOCK=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "dlpack" CONFIG_PATH "lib/cmake/dlpack")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dlpack/vcpkg.json
+++ b/ports/dlpack/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "dlpack",
+  "version": "0.8",
+  "description": "common in-memory tensor structure",
+  "homepage": "https://github.com/dmlc/dlpack",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -24,6 +24,10 @@
       "baseline": "1.13.0",
       "port-version": 0
     },
+    "dlpack": {
+      "baseline": "0.8",
+      "port-version": 0
+    },
     "eigen3": {
       "baseline": "3.4.0",
       "port-version": 2

--- a/versions/d-/dlpack.json
+++ b/versions/d-/dlpack.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "030bf66a1b5a31796185f0403c7b91870561c3f4",
+      "version": "0.8",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create a new port for later version of ONNXRuntime

### References

* https://github.com/dmlc/dlpack/releases/tag/v0.8

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`, `arm64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "dlpack"
            ],
            "baseline": "..."
        }
    ]
}
```
