### PR TITLE
[onnxruntime] Fix use of Eigen3, remove NuGet executable usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,15 @@ jobs:
             equal: [ main, << pipeline.git.branch >> ]
           steps:
            - save_cache:
-              key: v2352-caches-{{ .Branch }}
+              key: v2352-caches-main
               paths:
                 - C:/vcpkg-caches
       - save_cache:
           key: v2352-caches-{{ .Branch }}
+          paths:
+            - C:/vcpkg-caches
+      - save_cache:
+          key: v2352-caches-{{ checksum ".circleci/config.yml" }}
           paths:
             - C:/vcpkg-caches
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           keys:
             - v2352-caches-{{ .Branch }}
             - v2352-caches-{{ checksum ".circleci/config.yml" }}
+            - v2352-caches-update/circleci
             - v2352-caches-main
       - run:
           name: "Install: port-windows.txt"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,7 +187,7 @@ stages:
               path: $(vcpkg.default.binary.cache)
           - task: run-vcpkg@0
             inputs:
-              vcpkgArguments: "tensorflow-lite[gpu] onnxruntime[xnnpack]"
+              vcpkgArguments: "tensorflow-lite[gpu] onnxruntime[xnnpack,training]"
               vcpkgGitCommitId: $(vcpkg.commit)
           - task: CopyFiles@2
             displayName: "Copy logs in buildtrees"

--- a/ports/onnxruntime/fix-cmake.patch
+++ b/ports/onnxruntime/fix-cmake.patch
@@ -95,3 +95,15 @@ index 9c00703..eca3845 100644
      flatbuffers::flatbuffers Boost::mp11 safeint_interface
    )
  
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index fa936c2..48bd0fb 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -959,6 +959,7 @@ function(onnxruntime_set_compile_flags target_name)
+       endif()
+       target_compile_definitions(${target_name} PUBLIC -DNSYNC_ATOMIC_CPP11)
+       onnxruntime_add_include_to_target(${target_name} nsync::nsync_cpp)
++      onnxruntime_add_include_to_target(${target_name} Eigen3::Eigen)
+     endif()
+     foreach(ORT_FLAG ${ORT_PROVIDER_FLAGS})
+       target_compile_definitions(${target_name} PRIVATE ${ORT_FLAG})

--- a/ports/onnxruntime/onnxruntime_vcpkg_deps.cmake
+++ b/ports/onnxruntime/onnxruntime_vcpkg_deps.cmake
@@ -19,6 +19,7 @@ endif()
 # Flatbuffers
 find_package(flatbuffers CONFIG REQUIRED) # flatbuffers::flatbuffers
 list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES flatbuffers::flatbuffers)
+list(APPEND onnxruntime_EXTERNAL_LIBRARIES flatbuffers::flatbuffers)
 
 find_package(Protobuf CONFIG REQUIRED) # protobuf::libprotobuf protobuf::libprotobuf-lite
 if (onnxruntime_USE_FULL_PROTOBUF)
@@ -35,7 +36,7 @@ get_filename_component(ONNX_CUSTOM_PROTOC_EXECUTABLE "${Protobuf_PROTOC_EXECUTAB
 include(external/protobuf_function.cmake)
 
 find_package(date CONFIG REQUIRED)
-list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES date::date)
+list(APPEND onnxruntime_EXTERNAL_LIBRARIES date::date)
 
 find_package(Boost REQUIRED)
 find_path(BOOST_INCLUDEDIR "boost/mp11.hpp" REQUIRED)

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -4,7 +4,6 @@ endif()
 if(VCPKG_TARGET_IS_OSX AND ("framework" IN_LIST FEATURES))
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
-vcpkg_find_acquire_program(NUGET)
 
 # requires https://github.com/microsoft/onnxruntime/pull/18038 for later version of XNNPACK
 vcpkg_from_github(
@@ -148,7 +147,6 @@ vcpkg_cmake_configure(
     OPTIONS
         ${ARCH_OPTIONS}
         ${FEATURE_OPTIONS}
-        -DNUGET_EXE:FILEPATH:=${NUGET}
         -DPython_EXECUTABLE:FILEPATH=${PYTHON3}
         -DProtobuf_PROTOC_EXECUTABLE:FILEPATH=${PROTOC}
         # -DProtobuf_USE_STATIC_LIBS=OFF
@@ -175,7 +173,6 @@ vcpkg_cmake_configure(
         -Donnxruntime_ENABLE_MEMORY_PROFILE=OFF
         -Donnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1
     MAYBE_UNUSED_VARIABLES
-        NUGET_EXE
         onnxruntime_BUILD_WEBASSEMBLY
         onnxruntime_TENSORRT_PLACEHOLDER_BUILDER
         onnxruntime_USE_CUSTOM_DIRECTML

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -89,7 +89,7 @@ endif()
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
     # For some reason CUDA compiler detection is not working in WINDOWS_USE_MSBUILD
     if(NOT ("cuda" IN_LIST FEATURES))
-        set(GENERATOR_OPTIONS WINDOWS_USE_MSBUILD)
+        # set(GENERATOR_OPTIONS WINDOWS_USE_MSBUILD)
     endif()
 elseif(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
     set(GENERATOR_OPTIONS GENERATOR Xcode)
@@ -178,9 +178,6 @@ vcpkg_cmake_configure(
         onnxruntime_USE_CUSTOM_DIRECTML
         onnxruntime_NVCC_THREADS
 )
-if("training" IN_LIST FEATURES)
-    vcpkg_cmake_build(TARGET onnxruntime_training LOGFILE_BASE build-training)
-endif()
 vcpkg_cmake_build(TARGET onnxruntime LOGFILE_BASE build-onnxruntime)
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/onnxruntime PACKAGE_NAME onnxruntime)

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onnxruntime",
   "version-date": "2024-01-04",
+  "port-version": 1,
   "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
   "homepage": "https://www.onnxruntime.ai",
   "dependencies": [

--- a/test/self-hosted-cuda.json
+++ b/test/self-hosted-cuda.json
@@ -18,6 +18,7 @@
         "cuda",
         "directml",
         "python",
+        "training",
         "xnnpack"
       ],
       "platform": "x64 & windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -90,7 +90,7 @@
     },
     "onnxruntime": {
       "baseline": "2024-01-04",
-      "port-version": 0
+      "port-version": 1
     },
     "openssl": {
       "baseline": "3.1.3",

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6af6c57d2c15411b9baba5f49e5ecd5608fa9477",
+      "version-date": "2024-01-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "f89b1af1f550c094eec8a2f08862c8358f8b5df3",
       "version-date": "2024-01-04",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Remove NuGet usage in portfile.cmake. It is no longer used.
* Fix header search of Eigen3 in Linux build

### References

* #151
* #152

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                {
                    "name": "onnxruntime",
                    "features": [
                        "training",
                        "xnnpack"
                    ]
                }
            ],
            "baseline": "..."
        }
    ]
}
```
