### PR TITLE
[openssl3] update to 3.2.0

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.1.4
-    SHA512 04349ba554ddc5a9c26ff44714c1adca3c6431e98d11af5e7b6a5f58ed44e016da68c09cc53415716ab1936c6aaac04887ced470707dbc3f7816c04e06be69c1
+    REF openssl-3.2.0
+    SHA512 aaf4f13b7b8020be37837f8084ab7aa3db64e6eb1ecabf04473ed5bd09bcabb8790f0dc1f7604febbbf974702b1fbe41795a7b575e7f88b07cbe094493926a6b
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.1.4",
-  "port-version": 1,
+  "version-semver": "3.2.0",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,8 +101,8 @@
       "port-version": 1
     },
     "openssl3": {
-      "baseline": "3.1.4",
-      "port-version": 1
+      "baseline": "3.2.0",
+      "port-version": 0
     },
     "pthreadpool": {
       "baseline": "2023-09-12",

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e5b418e7879956f2a2ca203a2b0b34f050f155b",
+      "version-semver": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "027b5866ebd1f8f5073660e4dd37f2b7c2961e41",
       "version-semver": "3.1.4",
       "port-version": 1


### PR DESCRIPTION
### Changes

Update commit reference

### References

* https://github.com/openssl/openssl/releases/tag/openssl-3.2.0

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl3"
            ],
            "baseline": "..."
        }
    ]
}
```
