### PR TITLE
[opencl-headers] Create a new port

### DIFF
--- a/ports/opencl-headers/portfile.cmake
+++ b/ports/opencl-headers/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/OpenCL-Headers
+    REF v2023.02.06
+    SHA512 41730e80b267de45db9d7a3bcf9e0f29bfc86b25475a86d50180a7258e1240fc8c8f2ad3e222b03b3ef50c10ef63fb5b1647c056fec615e87965aa3196e8ac60
+    HEAD_REF main
+)
+
+file(INSTALL "${SOURCE_PATH}/CL" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opencl-headers/vcpkg.json
+++ b/ports/opencl-headers/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "opencl-headers",
+  "version-date": "2023-02-06",
+  "description": "Khronos OpenCL-Headers",
+  "homepage": "https://github.com/KhronosGroup/OpenCL-Headers"
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -37,12 +37,14 @@
       "name": "metal-cpp",
       "platform": "osx | ios"
     },
+    "opencl-headers",
+    "openssl3",
     {
       "name": "openssl3",
       "features": [
         "tools"
       ],
-      "platform": "windows | linux"
+      "platform": "windows"
     },
     "rvo2",
     "rvo2-3d",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -112,6 +112,10 @@
       "baseline": "2024-01-04",
       "port-version": 1
     },
+    "opencl-headers": {
+      "baseline": "2023-02-06",
+      "port-version": 0
+    },
     "openssl": {
       "baseline": "3.1.3",
       "port-version": 0

--- a/versions/o-/opencl-headers.json
+++ b/versions/o-/opencl-headers.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cede8377dc9c80cd6dc87fa3d2974508838d7c9a",
+      "version-date": "2023-02-06",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Support some header-only use of OpenCL.  
Check `opencl` in https://github.com/microsoft/vcpkg` for proper version updates.

### References

* https://github.com/KhronosGroup/OpenCL-Headers

### Triplet Support

The port is header only. All triplets will be supported.

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "opencl-headers"
            ],
            "baseline": "..."
        }
    ]
}
```
