### PR TITLE
Patch onnxruntime to compile with clang-cl

### DIFF
--- a/ports/onnxruntime/fix-clang-cl-simd-compile.patch
+++ b/ports/onnxruntime/fix-clang-cl-simd-compile.patch
@@ -1,0 +1,51 @@
+diff --git a/cmake/onnxruntime_mlas.cmake b/cmake/onnxruntime_mlas.cmake
+index bee83ff07c..04b4cf42b7 100644
+--- a/cmake/onnxruntime_mlas.cmake
++++ b/cmake/onnxruntime_mlas.cmake
+@@ -159,15 +159,27 @@ function(setup_mlas_source_for_windows)
+     )
+     set_source_files_properties(${mlas_platform_srcs_avx2} PROPERTIES COMPILE_FLAGS "/arch:AVX2")
+ 
++    file(GLOB_RECURSE mlas_platform_srcs_avx512 CONFIGURE_DEPENDS
++      "${MLAS_SRC_DIR}/intrinsics/avx512/*.cpp"
++    )
++    set(mlas_platform_srcs_amx "${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp")
++
++    # clang-cl requires us to enable the platform feature flags explicitly to compile the intrinsics code
++    # unlike MSVC. See: https://github.com/llvm/llvm-project/issues/53520
++    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++      set_source_files_properties(${mlas_platform_srcs_avx512} PROPERTIES COMPILE_FLAGS "/arch:AVX512")
++      set_source_files_properties(${mlas_platform_srcs_amx} PROPERTIES COMPILE_FLAGS "/arch:AVX512 -mamx-tile -mamx-int8")
++    endif()
++
+     target_sources(onnxruntime_mlas PRIVATE
+       ${MLAS_SRC_DIR}/dgemm.cpp
+       ${mlas_platform_srcs_avx}
+       ${mlas_platform_srcs_avx2}
+-      ${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp
++      ${mlas_platform_srcs_avx512}
++      ${mlas_platform_srcs_amx}
+       ${MLAS_SRC_DIR}/qgemm_kernel_avx2.cpp
+       ${MLAS_SRC_DIR}/qgemm_kernel_sse.cpp
+       ${MLAS_SRC_DIR}/qgemm_kernel_sse41.cpp
+-      ${MLAS_SRC_DIR}/intrinsics/avx512/quantize_avx512f.cpp
+       ${MLAS_SRC_DIR}/amd64/QgemmU8S8KernelAmx.asm
+       ${MLAS_SRC_DIR}/amd64/QgemmU8S8KernelAvx2.asm
+       ${MLAS_SRC_DIR}/amd64/QgemmU8U8KernelAvx2.asm
+@@ -205,9 +217,15 @@ function(setup_mlas_source_for_windows)
+       ${MLAS_SRC_DIR}/amd64/ErfKernelFma3.asm
+     )
+     if (NOT onnxruntime_ORT_MINIMAL_BUILD)
+-      target_sources(onnxruntime_mlas PRIVATE
++      set(onnxruntime_mlas_q4gemm_avx512
+         ${MLAS_SRC_DIR}/q4gemm_avx512.cpp
+       )
++      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++        # clang-cl requires us to enable the platform feature flags explicitly to compile the intrinsics code
++        # unlike MSVC. See: https://github.com/llvm/llvm-project/issues/53520
++        set_source_files_properties(${onnxruntime_mlas_q4gemm_avx512} PROPERTIES COMPILE_FLAGS "/arch:AVX512 -mavx512vnni")
++      endif()
++      target_sources(onnxruntime_mlas PRIVATE ${onnxruntime_mlas_q4gemm_avx512})
+     endif()
+   else()
+     target_sources(onnxruntime_mlas PRIVATE

--- a/ports/onnxruntime/fix-clang-cl-simd-compile.patch
+++ b/ports/onnxruntime/fix-clang-cl-simd-compile.patch
@@ -49,3 +49,32 @@ index bee83ff07c..04b4cf42b7 100644
      endif()
    else()
      target_sources(onnxruntime_mlas PRIVATE
+diff --git a/cmake/onnxruntime_mlas.cmake b/cmake/onnxruntime_mlas.cmake
+index 5c294b5..a466c77 100644
+--- a/cmake/onnxruntime_mlas.cmake
++++ b/cmake/onnxruntime_mlas.cmake
+@@ -169,6 +169,9 @@ function(setup_mlas_source_for_windows)
+     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+       set_source_files_properties(${mlas_platform_srcs_avx512} PROPERTIES COMPILE_FLAGS "/arch:AVX512")
+       set_source_files_properties(${mlas_platform_srcs_amx} PROPERTIES COMPILE_FLAGS "/arch:AVX512 -mamx-tile -mamx-int8")
++      # https://clang.llvm.org/docs/UsersManual.html#cpu-architectures-features-and-limitations
++      set_source_files_properties(${MLAS_SRC_DIR}/qgemm_kernel_sse.cpp PROPERTIES COMPILE_FLAGS "-march=x86-64")
++      set_source_files_properties(${MLAS_SRC_DIR}/qgemm_kernel_sse41.cpp PROPERTIES COMPILE_FLAGS "-march=x86-64-v2")
+     endif()
+ 
+     target_sources(onnxruntime_mlas PRIVATE
+diff --git a/onnxruntime/core/mlas/lib/qgemm_kernel_sse41.cpp b/onnxruntime/core/mlas/lib/qgemm_kernel_sse41.cpp
+index 68931c5..6c095bd 100644
+--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sse41.cpp
++++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sse41.cpp
+@@ -16,6 +16,10 @@ Abstract:
+ 
+ #include "mlasi.h"
+ #include "qgemm.h"
++#if defined(__clang__)
++#include <smmintrin.h>
++#include <tmmintrin.h>
++#endif
+ 
+ // N.B. MSVC does not require turning on SSE 4.1 intrinsics and the current use
+ // for this code is Windows only, so restrict this kernel to that environment.

--- a/ports/onnxruntime/fix-llvm-rc-unicode.patch
+++ b/ports/onnxruntime/fix-llvm-rc-unicode.patch
@@ -1,0 +1,16 @@
+diff --git a/onnxruntime/core/dll/onnxruntime.rc b/onnxruntime/core/dll/onnxruntime.rc
+index 4b08dfdb7e..c566a4f713 100644
+--- a/onnxruntime/core/dll/onnxruntime.rc
++++ b/onnxruntime/core/dll/onnxruntime.rc
+@@ -32,9 +32,9 @@ BEGIN
+             VALUE "FileDescription",  "ONNX Runtime"
+             VALUE "FileVersion",      VER_STRING
+             VALUE "InternalName",     "ONNX Runtime"
+-            VALUE "LegalCopyright",   "\251 Microsoft Corporation. All rights reserved."
++            VALUE "LegalCopyright",   L"\251 Microsoft Corporation. All rights reserved."
+             VALUE "OriginalFilename", FILE_NAME
+-            VALUE "ProductName",      "Microsoft\256 Windows\256 Operating System"
++            VALUE "ProductName",      L"Microsoft\256 Windows\256 Operating System"
+             VALUE "ProductVersion",   VER_STRING
+         END
+     END

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_from_github(
         fix-cmake.patch
         fix-source-flatbuffers.patch
         fix-sources.patch
+        fix-clang-cl-simd-compile.patch
+        fix-llvm-rc-unicode.patch
 )
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/onnxruntime_vcpkg_deps.cmake" DESTINATION "${SOURCE_PATH}/cmake/external")
 

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "onnxruntime",
   "version-date": "2024-01-04",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
   "homepage": "https://www.onnxruntime.ai",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -110,7 +110,7 @@
     },
     "onnxruntime": {
       "baseline": "2024-01-04",
-      "port-version": 1
+      "port-version": 2
     },
     "openssl": {
       "baseline": "3.1.3",

--- a/versions/o-/onnxruntime.json
+++ b/versions/o-/onnxruntime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "233f074d172ba82b09562457e252601b04fc99cb",
+      "version-date": "2024-01-04",
+      "port-version": 2
+    },
+    {
       "git-tree": "6af6c57d2c15411b9baba5f49e5ecd5608fa9477",
       "version-date": "2024-01-04",
       "port-version": 1


### PR DESCRIPTION
### Changes
Add some patches to the onnxruntime port to handle issues with llvm-rc and clang-cl related to unicode in the rc file and clang-cl needing simd flags enabled when compiling SIMD code.
...

### Triplet Support

* `x64-windows` (MSVC and Clang-Cl)