### PR TITLE
[d3d12-transition-layer] Create a new port

### DIFF
--- a/ports/d3d12-transition-layer/fix-vcpkg.patch
+++ b/ports/d3d12-transition-layer/fix-vcpkg.patch
@@ -1,0 +1,71 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03a0c2a..c428d45 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,13 +6,8 @@ project(d3d12translationlayer)
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-    DirectX-Headers
+-    GIT_REPOSITORY https://github.com/Microsoft/DirectX-Headers.git
+-    GIT_TAG v1.610.0
+-)
+-FetchContent_MakeAvailable(DirectX-Headers)
++include(GNUInstallDirs)
++find_package(directx-headers CONFIG REQUIRED)
+ 
+ option(USE_PIX "Enable the use of PIX markers" ON)
+ 
+diff --git a/include/D3D12TranslationLayerIncludes.h b/include/D3D12TranslationLayerIncludes.h
+index 48d9fc4..780c531 100644
+--- a/include/D3D12TranslationLayerIncludes.h
++++ b/include/D3D12TranslationLayerIncludes.h
+@@ -17,14 +17,14 @@
+ #include "Util.hpp"
+ #include "DeviceChild.hpp"
+ 
+-#include <BlockAllocators.h>
++#include "BlockAllocators.h"
+ #include "Allocator.h"
+ #include "XPlatHelpers.h"
+ 
+-#include <ThreadPool.hpp>
+-#include <segmented_stack.h>
+-#include <formatdesc.hpp>
+-#include <dxgiColorSpaceHelper.h>
++#include "ThreadPool.hpp"
++#include "segmented_stack.h"
++#include "FormatDesc.hpp"
++#include "DXGIColorSpaceHelper.h"
+ 
+ #include "MaxFrameLatencyHelper.hpp"
+ #include "Shader.hpp"
+@@ -58,7 +58,7 @@
+ #include "Shader.inl"
+ #include "ImmediateContext.inl"
+ #include "CommandListManager.inl"
+-#include <BlockAllocators.inl>
++#include "BlockAllocators.inl"
+ 
+ #ifndef MICROSOFT_TELEMETRY_ASSERT
+ #define MICROSOFT_TELEMETRY_ASSERT(x) assert(x)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e9d9537..8180fe1 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -158,7 +158,12 @@ if (HAS_WDK)
+ 		../include/ShaderBinary.h
+         ../include/SharedResourceHelpers.hpp)
+ 	target_link_libraries(d3d12translationlayer_wdk d3d12translationlayer)
+-
++	install(TARGETS d3d12translationlayer_wdk LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ else()
+     message(WARNING "Only adding SDK-dependent projects.")
+ endif()
++
++install(TARGETS d3d12translationlayer LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(FILES ${INC} ${INL} ../include/XPlatHelpers.h
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/D3D12TranslationLayer
++)

--- a/ports/d3d12-transition-layer/portfile.cmake
+++ b/ports/d3d12-transition-layer/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# todo: MicrosoftTelemetry from https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerSharedLib/Public/Telemetry/MicrosoftTelemetry.h
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/D3D12TranslationLayer
+    REF 283fe2eb00d75a3e4b59d935f486fffa4eac0b4d
+    SHA512 837c8f520ffee924e11a843ab9353ed8d27ff54e2f7c746fe771e1d955637430fd351f6020594fa4b9340270d4b9c0472d37780bbe174444b05e0a48a65d7805
+    PATCHES
+        fix-vcpkg.patch
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+    OPTIONS
+        -DUSE_PIX=OFF
+        -DHAS_WDK=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/include/D3D12TranslationLayer/pch.h"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/d3d12-transition-layer/vcpkg.json
+++ b/ports/d3d12-transition-layer/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "d3d12-transition-layer",
+  "version-date": "2023-12-13",
+  "description": "A library containing utilities for mapping higher-level graphics work to D3D12",
+  "homepage": "https://github.com/microsoft/D3D12TranslationLayer",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "directx-headers",
+      "version>=": "1.610.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -17,6 +17,10 @@
       "name": "coreml-tools",
       "platform": "osx | ios"
     },
+    {
+      "name": "d3d12-transition-layer",
+      "platform": "windows"
+    },
     "etcpak",
     {
       "name": "libdispatch",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -20,6 +20,10 @@
       "baseline": "2023-11-29",
       "port-version": 0
     },
+    "d3d12-transition-layer": {
+      "baseline": "2023-12-13",
+      "port-version": 0
+    },
     "directml": {
       "baseline": "1.13.0",
       "port-version": 0

--- a/versions/d-/d3d12-transition-layer.json
+++ b/versions/d-/d3d12-transition-layer.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "dd9abec7585b29947948b84a8ff636877b8f734b",
+      "version-date": "2023-12-13",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Work to support https://github.com/microsoft/openclon12

### References

* https://github.com/microsoft/D3D12TranslationLayer

### Triplet Support

* `x64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "d3d12-transition-layer"
            ],
            "baseline": "..."
        }
    ]
}
```
