### PR TITLE
[opecl,opencl-headers] Create OpenCL ports from KhronosGroup repos

### DIFF
--- a/ports/opencl-headers/portfile.cmake
+++ b/ports/opencl-headers/portfile.cmake
@@ -1,12 +1,44 @@
+# OpenCLHeaders
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
+    OUT_SOURCE_PATH CL_SOURCE_PATH
     REPO KhronosGroup/OpenCL-Headers
-    REF v2023.02.06
-    SHA512 41730e80b267de45db9d7a3bcf9e0f29bfc86b25475a86d50180a7258e1240fc8c8f2ad3e222b03b3ef50c10ef63fb5b1647c056fec615e87965aa3196e8ac60
+    REF v2023.12.14
+    SHA512 71a21f32cc2d956ef52ea197a95f21a3df5cf4e6888b533eb8cc66be0025fafe9b6477d3de813cb1ae6303032c80bc10b5e5ab1c71074f1662a6b5296fffd3d3
     HEAD_REF main
 )
 
-file(INSTALL "${SOURCE_PATH}/CL" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+vcpkg_cmake_configure(
+  SOURCE_PATH "${CL_SOURCE_PATH}"
+  OPTIONS
+    -DOPENCL_HEADERS_BUILD_CXX_TESTS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/OpenCLHeaders PACKAGE_NAME OpenCLHeaders)
+vcpkg_fixup_pkgconfig() # OpenCL-Headers
+
+# OpenCLHeadersCpp
+vcpkg_from_github(
+    OUT_SOURCE_PATH CLHPP_SOURCE_PATH
+    REPO KhronosGroup/OpenCL-CLHPP
+    REF v2023.12.14
+    SHA512 a90152d2f9c57d4724ef3ea33e1311914e49659042e916e467a9f16877d348ed62f909fe8423589976669b25241a3b996fbd7ac235a44e35947d1b87d3e3ef2b
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${CLHPP_SOURCE_PATH}"
+  OPTIONS
+    -DOpenCLHeaders_DIR:PATH=${CURRENT_PACKAGES_DIR}/share/OpenCLHeaders
+    -DBUILD_DOCS=OFF
+    -DBUILD_TESTING=OFF
+    -DBUILD_EXAMPLES=OFF
+    -DCLHPP_BUILD_TESTS=OFF
+    -DOPENCL_CLHPP_BUILD_TESTING=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/OpenCLHeadersCpp PACKAGE_NAME OpenCLHeadersCpp)
+vcpkg_fixup_pkgconfig() # OpenCL-CLHPP
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${CL_SOURCE_PATH}/LICENSE")

--- a/ports/opencl-headers/vcpkg.json
+++ b/ports/opencl-headers/vcpkg.json
@@ -1,6 +1,16 @@
 {
   "name": "opencl-headers",
-  "version-date": "2023-12-13",
+  "version-date": "2023-12-14",
   "description": "Khronos OpenCL-Headers",
-  "homepage": "https://github.com/KhronosGroup/OpenCL-Headers"
+  "homepage": "https://github.com/KhronosGroup/OpenCL-Headers",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/opencl-headers/vcpkg.json
+++ b/ports/opencl-headers/vcpkg.json
@@ -3,6 +3,7 @@
   "version-date": "2023-12-14",
   "description": "Khronos OpenCL-Headers",
   "homepage": "https://github.com/KhronosGroup/OpenCL-Headers",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/opencl/portfile.cmake
+++ b/ports/opencl/portfile.cmake
@@ -1,0 +1,35 @@
+# Check `opencl` port of https://github.com/microsoft/vcpkg
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/OpenCL-ICD-Loader
+    REF v2023.12.14
+    SHA512 b30aa0b856e6c73450fc23f768201ac01d3c5519a14305c79127debc6407be656b68ae2bd527bb7225d4268865f7bdf0b384279eb78b2806725d37ab940bf56e
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DENABLE_OPENCL_LAYERINFO=OFF
+    -DOPENCL_ICD_LOADER_HEADERS_DIR:PATH=${CURRENT_INSTALLED_DIR}/include
+)
+
+vcpkg_cmake_build(TARGET OpenCL)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/OpenCLICDLoader PACKAGE_NAME OpenCLICDLoader)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_fixup_pkgconfig()
+endif()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+  "${CURRENT_PACKAGES_DIR}/debug/include"
+  "${CURRENT_PACKAGES_DIR}/debug/share"
+  "${CURRENT_PACKAGES_DIR}/include"
+)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opencl/vcpkg.json
+++ b/ports/opencl/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "opencl",
+  "version-date": "2023-12-14",
+  "description": "C/C++ headers and ICD loader (Installable Client Driver) for OpenCL",
+  "homepage": "https://github.com/KhronosGroup/OpenCL-ICD-Loader",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "opencl-headers",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -41,6 +41,10 @@
       "name": "metal-cpp",
       "platform": "osx | ios"
     },
+    {
+      "name": "opencl",
+      "platform": "windows | linux"
+    },
     "openssl3",
     {
       "name": "openssl3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -117,7 +117,7 @@
       "port-version": 2
     },
     "opencl-headers": {
-      "baseline": "2023-12-13",
+      "baseline": "2023-12-14",
       "port-version": 0
     },
     "openssl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -116,6 +116,10 @@
       "baseline": "2024-01-04",
       "port-version": 2
     },
+    "opencl": {
+      "baseline": "2023-12-14",
+      "port-version": 0
+    },
     "opencl-headers": {
       "baseline": "2023-12-14",
       "port-version": 0

--- a/versions/o-/opencl-headers.json
+++ b/versions/o-/opencl-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0f50cee0ede373413029e96cb19ea2a811f3fee",
+      "version-date": "2023-12-14",
+      "port-version": 0
+    },
+    {
       "git-tree": "1edcf9f2ffaf0c12b35f71a59f66c43365034545",
       "version-date": "2023-12-13",
       "port-version": 0

--- a/versions/o-/opencl.json
+++ b/versions/o-/opencl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "44ff79ad28f36b93f5f9d1c2c317cc70f60ebdfe",
+      "version-date": "2023-12-14",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Update `opencl-headers` and create `opencl` with the `v2023.12.14` version

### References

* https://github.com/KhronosGroup/OpenCL-Headers
* https://github.com/KhronosGroup/OpenCL-CLHPP
* https://github.com/KhronosGroup/OpenCL-ICD-Loader

### Triplet Support

Does NOT support 

* `x64-uwp`
* `arm64-uwp`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "opencl-headers",
                "opencl"
            ],
            "baseline": "..."
        }
    ]
}
```
