### PR TITLE
[opencl-on-dx12] Create a new port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .vscode
 vcpkg-configuration.json
 
+buildtrees
+installed
+packages
+
 # Created by https://www.toptal.com/developers/gitignore/api/cmake,c++,visualstudiocode,powershell
 # Edit at https://www.toptal.com/developers/gitignore?templates=cmake,c++,visualstudiocode,powershell
 

--- a/ports/opencl-on-dx12/fix-vcpkg.patch
+++ b/ports/opencl-on-dx12/fix-vcpkg.patch
@@ -1,0 +1,69 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3fc0eed..21b94ec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # Licensed under the MIT License.
+ cmake_minimum_required(VERSION 3.14)
+ project(openclon12)
+-include(FetchContent)
++include(GNUInstallDirs)
+ 
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+@@ -13,43 +13,29 @@ file(GLOB_RECURSE SRC CONFIGURE_DEPENDS src/*.cpp src/*.def)
+ file(GLOB_RECURSE INC include/*.h include/*.hpp)
+ file(GLOB_RECURSE EXTERNAL_INC external/*.h external/*.hpp)
+ 
+-FetchContent_Declare(
+-    d3d12translationlayer
+-    GIT_REPOSITORY https://github.com/microsoft/D3D12TranslationLayer.git
+-    GIT_TAG        e77b6a16a64dd584772f2b0123209cd3f96d81ce
+-)
+-FetchContent_MakeAvailable(d3d12translationlayer)
++find_path(D3D12TRANSLATIONLAYER_INCLUDE_DIR NAMES D3D12TranslationLayer/D3D12TranslationLayerIncludes.h REQUIRED)
++find_library(D3D12TRANSLATIONLAYER_LIB NAMES d3d12translationlayer REQUIRED)
+ 
+-FetchContent_Declare(
+-    opencl_headers
+-    GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
+-    GIT_TAG 1bb9ec797d14abed6167e3a3d66ede25a702a5c7
+-)
+-FetchContent_MakeAvailable(opencl_headers)
+-add_library(OpenCL::Headers ALIAS Headers)
+-
+-set(WIL_BUILD_PACKAGING OFF CACHE BOOL "" FORCE)
+-set(WIL_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+-FetchContent_Declare(
+-    wil
+-    GIT_REPOSITORY https://github.com/microsoft/wil.git
+-    GIT_TAG ed429e64eb3b91848bf19c17e1431c1b0f2c6d2b
+-)
+-FetchContent_MakeAvailable(wil)
++find_path(OpenCL_INCLUDE_DIR NAMES CL/cl.h REQUIRED)
++
++find_package(wil CONFIG REQUIRED) # WIL::WIL
+ 
+ add_library(openclon12 SHARED ${SRC} ${INC} ${EXTERNAL_INC})
+ target_include_directories(openclon12
+     PRIVATE include
+     PRIVATE external
+-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++    PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${D3D12TRANSLATIONLAYER_INCLUDE_DIR}/D3D12TranslationLayer ${OpenCL_INCLUDE_DIR})
+ target_link_libraries(openclon12
+-    d3d12translationlayer
+-    OpenCL::Headers
+-    WIL
++    PRIVATE ${D3D12TRANSLATIONLAYER_LIB} WIL::WIL dxcore d3d12 dxgi
+     user32
+     gdi32)
+ source_group("Header Files\\External" FILES ${EXTERNAL_INC})
+ 
++install(FILES ${INC} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenCLOn12)
++install(TARGETS openclon12
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+ option(BUILD_TESTS "Build tests" ON)
+ 
+ if (BUILD_TESTS)

--- a/ports/opencl-on-dx12/portfile.cmake
+++ b/ports/opencl-on-dx12/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(MS_TELEMETRY_H_PATH
+    URLS "https://raw.githubusercontent.com/microsoft/winget-cli/master/src/AppInstallerSharedLib/Public/Telemetry/MicrosoftTelemetry.h"
+    FILENAME MicrosoftTelemetry.h
+    SHA512 33d229ee1e7eb9d176629d94eaa24a4ec1deb384a8b80a84834b5ca58bd0bf814dfd6051e29909e52cc293587c3edcfcf307873c43ec5bd8abb84eafa929dfd9
+)
+# file(INSTALL "${MS_TELEMETRY_H_PATH}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/Telemetry")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/OpenCLOn12
+    REF b9cef1443007ed3cd4e39a03666a539f91e159e5
+    SHA512 13aa2abe8ff0e3f14ed481bd45d8741d0783a40094ea1e70280414751f40784b4c82b9da60224bda51bf3d5c491b4471242118bc7ecf42b6497a55e9276afde7
+    PATCHES
+        fix-vcpkg.patch
+    HEAD_REF master
+)
+file(COPY "${MS_TELEMETRY_H_PATH}" DESTINATION "${SOURCE_PATH}/external")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+    OPTIONS
+        -DBUILD_TESTS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opencl-on-dx12/portfile.cmake
+++ b/ports/opencl-on-dx12/portfile.cmake
@@ -1,5 +1,6 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+# note: The URL is using 'master' branch. This is intended, so the port can detect some changes...
 vcpkg_download_distfile(MS_TELEMETRY_H_PATH
     URLS "https://raw.githubusercontent.com/microsoft/winget-cli/master/src/AppInstallerSharedLib/Public/Telemetry/MicrosoftTelemetry.h"
     FILENAME MicrosoftTelemetry.h
@@ -31,5 +32,5 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
-
+file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opencl-on-dx12/vcpkg.json
+++ b/ports/opencl-on-dx12/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "opencl-on-dx12",
+  "version-date": "2023-12-08",
+  "description": "The OpenCL-on-D3D12 mapping layer",
+  "homepage": "https://github.com/microsoft/OpenCLOn12",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    "d3d12-transition-layer",
+    {
+      "name": "directx-headers",
+      "version>=": "1.610.0"
+    },
+    "opencl-headers",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "wil"
+  ]
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -21,6 +21,10 @@
       "name": "d3d12-transition-layer",
       "platform": "windows"
     },
+    {
+      "name": "opencl-on-dx12",
+      "platform": "windows"
+    },
     "etcpak",
     {
       "name": "libdispatch",


### PR DESCRIPTION
### Changes

Create a new port for Windows DirectX 12

Used the latest commit at the moment
https://github.com/microsoft/OpenCLOn12/commits/master/

### References

* https://github.com/microsoft/openclon12
* #164
* #166
* #167

### Triplet Support

* `x64-windows`
* `arm64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "opencl-headers",
                "opencl-on-dx12"
            ],
            "baseline": "..."
        }
    ]
}
```
