### PR TITLE
[openssl3] Support `.pc` file generation

### DIFF
--- a/ports/openssl3/install-pc-files.cmake
+++ b/ports/openssl3/install-pc-files.cmake
@@ -1,0 +1,33 @@
+# Copied from https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake
+function(install_pc_file name pc_data)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/openssl.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${name}.pc" @ONLY)
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/openssl.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${name}.pc" @ONLY)
+    endif()
+endfunction()
+
+install_pc_file(openssl [[
+Name: OpenSSL
+Description: Secure Sockets Layer and cryptography libraries and tools
+Requires: libssl libcrypto
+]])
+
+install_pc_file(libssl [[
+Name: OpenSSL-libssl
+Description: Secure Sockets Layer and cryptography libraries
+Libs: -L"${libdir}" -llibssl
+Requires: libcrypto
+Cflags: -I"${includedir}"
+]])
+
+install_pc_file(libcrypto [[
+Name: OpenSSL-libcrypto
+Description: OpenSSL cryptography library
+Libs: -L"${libdir}" -llibcrypto
+Libs.private: -lcrypt32 -lws2_32 -ladvapi32 -luser32
+Cflags: -I"${includedir}"
+]])
+
+vcpkg_fixup_pkgconfig()

--- a/ports/openssl3/openssl.pc.in
+++ b/ports/openssl3/openssl.pc.in
@@ -1,0 +1,6 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+Version: @VERSION@
+@pc_data@

--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -169,9 +169,13 @@ else()
     if(EXISTS "${CURRENT_PACKAGES_DIR}/lib64")
         file(RENAME "${CURRENT_PACKAGES_DIR}/lib64" "${CURRENT_PACKAGES_DIR}/lib")
     endif()
-    vcpkg_fixup_pkgconfig()
 
 endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    include("${CMAKE_CURRENT_LIST_DIR}/install-pc-files.cmake")
+endif()
+vcpkg_fixup_pkgconfig()
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES openssl AUTO_CLEAN)

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,12 +1,14 @@
 {
   "name": "openssl3",
   "version-semver": "3.2.0",
+  "port-version": 1,
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0",
   "features": {
     "tools": {
-      "description": "Buind/Install OpenSSL CLI tools"
+      "description": "Buind/Install OpenSSL CLI tools",
+      "supports": "windows"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -134,7 +134,7 @@
     },
     "openssl3": {
       "baseline": "3.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pthreadpool": {
       "baseline": "2023-09-12",

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c66760e99d9c408e878d7855c7e3b106a0f83d06",
+      "version-semver": "3.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7e5b418e7879956f2a2ca203a2b0b34f050f155b",
       "version-semver": "3.2.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

Create `.pc` files in Windows platform install

* `tools` will be Windows only (the other platforms will be fixed soon)

### References

* https://github.com/microsoft/vcpkg/blob/master/ports/openssl
* https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake

### Triplet Support

* `x64-windows`
* `arm64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl3"
            ],
            "baseline": "..."
        }
    ]
}
```
