### PR TITLE
[openssl3,openssl] update to v3.2.1

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -1,1 +1,2 @@
+# see port/openssl3 for the details
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl",
-  "version-semver": "3.1.3",
+  "version-semver": "3.2.1",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0",

--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.2.0
-    SHA512 aaf4f13b7b8020be37837f8084ab7aa3db64e6eb1ecabf04473ed5bd09bcabb8790f0dc1f7604febbbf974702b1fbe41795a7b575e7f88b07cbe094493926a6b
+    REF openssl-3.2.1
+    SHA512 3eed5903f37ac728522cbb0ea0081f1d5a62d9420366d487f838dc22c31813c58584838400bd3d09518608e1e71bafcb1ff83713d351e4876da6625d5543fef6
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.2.0",
-  "port-version": 1,
+  "version-semver": "3.2.1",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -125,7 +125,7 @@
       "port-version": 0
     },
     "openssl": {
-      "baseline": "3.1.3",
+      "baseline": "3.2.1",
       "port-version": 0
     },
     "openssl1": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -133,8 +133,8 @@
       "port-version": 1
     },
     "openssl3": {
-      "baseline": "3.2.0",
-      "port-version": 1
+      "baseline": "3.2.1",
+      "port-version": 0
     },
     "pthreadpool": {
       "baseline": "2023-09-12",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "235dfd2a5cd9a85c647f02542742b0ef55afb2b7",
+      "version-semver": "3.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2893bc9344f188be288514e424d342765a6b620d",
       "version-semver": "3.1.3",
       "port-version": 0

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8b62816caba74a76b97b11d626946c1b3ed91a9",
+      "version-semver": "3.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c66760e99d9c408e878d7855c7e3b106a0f83d06",
       "version-semver": "3.2.0",
       "port-version": 1


### PR DESCRIPTION
### Changes

Update to the latest version

### References

* https://github.com/openssl/openssl/releases/tag/openssl-3.2.1
* #169 (for future works)

### Triplet Support

All available triplets of the port

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openssl",
                "openssl3"
            ],
            "baseline": "..."
        }
    ]
}
```
