### PR TITLE
[nvidia-cutlass] Create a new port with v3.4.0

### DIFF
--- a/ports/nvidia-cutlass/fix-cmake.patch
+++ b/ports/nvidia-cutlass/fix-cmake.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 114d793..7a05453 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -668,7 +668,7 @@ include(CTest)
+ enable_testing()
+ 
+ if (CUTLASS_ENABLE_GTEST_UNIT_TESTS)
+-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/googletest.cmake)
++  find_package(GTest CONFIG REQUIRED) # GTest::gtest GTest::gmock
+ endif()
+ 
+ if (NOT TARGET test_all)
+diff --git a/test/unit/CMakeLists.txt b/test/unit/CMakeLists.txt
+index 16252a0..800ffc6 100644
+--- a/test/unit/CMakeLists.txt
++++ b/test/unit/CMakeLists.txt
+@@ -42,7 +42,7 @@ target_link_libraries(
+   CUTLASS
+   cutlass_tools_util_includes
+   $<$<BOOL:${CUTLASS_ENABLE_CUBLAS}>:nvidia::cublas>
+-  gtest
++  GTest::gtest
+   cudart
+   cuda_driver
+   )
+@@ -84,7 +84,7 @@ function(cutlass_test_unit_add_executable NAME)
+     target_link_libraries(
+       ${NAME}
+       PUBLIC
+-      gtest
++      GTest::gtest
+     )
+   else()
+     target_link_libraries(
+diff --git a/test/unit/core/CMakeLists.txt b/test/unit/core/CMakeLists.txt
+index 965c050..a11c0e8 100644
+--- a/test/unit/core/CMakeLists.txt
++++ b/test/unit/core/CMakeLists.txt
+@@ -45,6 +45,10 @@ cutlass_test_unit_add_executable(
+   functional.cu
+   )
+ 
++target_include_directories(cutlass_test_unit_core PUBLIC
++  $<BUILD_INTERFACE:${CUTLASS_INCLUDE_DIR}>
++  $<BUILD_INTERFACE:${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}>
++)
+ #
+ # CUTLASS 3x increases the host compiler requirements to C++17. However, there are
+ # certain existing integrations that will benefit from maintaining C++11 compatibility.

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -1,0 +1,60 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/cutlass
+    REF v3.4.0
+    SHA512 6debdfa0ffbb9c14293619a281e864ac16592f64856e4a54ae456a79cbce3ec2f5068031f4eae589e72fb10c3c61f1fa6d3fa14650754a27c4b12e14774e7f75
+    PATCHES
+        fix-cmake.patch
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools CUTLASS_ENABLE_TOOLS
+        tools CUTLASS_ENABLE_PROFILER
+        test  CUTLASS_ENABLE_TESTS
+        test  CUTLASS_ENABLE_GTEST_UNIT_TESTS
+        test  CUTLASS_INSTALL_TESTS
+)
+
+if("tools" IN_LIST FEATURES)
+    x_vcpkg_get_python_packages(
+        PYTHON_VERSION 3
+        PACKAGES numpy
+        OUT_PYTHON_VAR PYTHON3
+    )
+    get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
+else()
+    vcpkg_find_acquire_program(PYTHON3)
+    get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
+endif()
+vcpkg_add_to_path(PREPEND "${PYTHON_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DCUTLASS_REVISION:STRING=v3.4.0
+        -DCUTLASS_ENABLE_HEADERS_ONLY=ON
+        -DCUTLASS_ENABLE_LIBRARY=ON
+        -DCUTLASS_ENABLE_EXAMPLES=OFF
+        -DCUTLASS_ENABLE_PERFORMANCE=OFF
+        -DCUTLASS_LIBRARY_OPERATIONS:STRING=all
+        -DCUTLASS_LIBRARY_KERNELS:STRING=all
+        -DPython3_EXECUTABLE:FILEPATH=${PYTHON3}
+    MAYBE_UNUSED_VARIABLES
+        CUTLASS_LIBRARY_OPERATIONS
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/NvidiaCutlass PACKAGE_NAME NvidiaCutlass)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/test"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "nvidia-cutlass",
+  "version-semver": "3.4.0",
+  "description": "CUDA Templates for Linear Algebra Subroutines",
+  "homepage": "https://github.com/NVIDIA/cutlass",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "cuda",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/test/self-hosted-cuda.json
+++ b/test/self-hosted-cuda.json
@@ -14,6 +14,7 @@
       "platform": "x64 & windows"
     },
     "nvidia-cnmem",
+    "nvidia-cutlass",
     "nvidia-tools-extension-sdk",
     "nvidia-triton-common",
     "nvidia-triton-core",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -92,6 +92,10 @@
       "baseline": "2018-11-28",
       "port-version": 0
     },
+    "nvidia-cutlass": {
+      "baseline": "3.4.0",
+      "port-version": 0
+    },
     "nvidia-tools-extension-sdk": {
       "baseline": "3.1.0",
       "port-version": 0

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "75c26a2bd20f4cbd49b9ed5189b9eb2a21e30007",
+      "version-semver": "3.4.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create a new port with https://github.com/NVIDIA/cutlass

### References

* https://github.com/NVIDIA/cutlass/releases/tag/v3.4.0

### Triplet Support

* `x64-windows`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "nvidia-cutlass"
            ],
            "baseline": "..."
        }
    ]
}
```
