### PR TITLE
[directml] Update to 1.13.1

### DIFF
--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -50,9 +50,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
     file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.pdb"        DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.Debug.dll"  DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.Debug.pdb"  DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    # debug/release will use same copy
-    file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${CURRENT_PACKAGES_DIR}/lib/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 elseif(VCPKG_TARGET_IS_LINUX)
     file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/libdirectml.so"  DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 else()
@@ -60,6 +57,7 @@ else()
 endif()
 
 file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE-CODE.txt"
              "${SOURCE_PATH}/README.md"

--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -5,7 +5,7 @@ set(ENV{NUGET_PACKAGES} "${BUILDTREES_DIR}/nuget")
 
 # see https://www.nuget.org/packages/Microsoft.AI.DirectML/
 set(PACKAGE_NAME    "Microsoft.AI.DirectML")
-set(PACKAGE_VERSION "1.13.0")
+set(PACKAGE_VERSION "1.13.1")
 
 file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}")
 vcpkg_execute_required_process(
@@ -17,11 +17,16 @@ vcpkg_execute_required_process(
 
 get_filename_component(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}.${PACKAGE_VERSION}" ABSOLUTE)
 if(VCPKG_TARGET_IS_WINDOWS)
-    # todo: x64-xbox?
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
         set(TRIPLE "x64-win")
+        # check community triplets...
+        if(DEFINED VCPKG_XBOX_CONSOLE_TARGET AND (VCPKG_XBOX_CONSOLE_TARGET MATCHES "scarlett"))
+            set(TRIPLE "x64-xbox-scarlett-231000")
+        endif()
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
         set(TRIPLE "x86-win")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64ec")
+        set(TRIPLE "arm64ec-win")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
         set(TRIPLE "arm64-win")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
@@ -56,9 +61,9 @@ endif()
 
 file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(INSTALL "${SOURCE_PATH}/LICENSE-CODE.txt"
              "${SOURCE_PATH}/README.md"
              "${SOURCE_PATH}/ThirdPartyNotices.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directml",
-  "version-semver": "1.13.0",
+  "version-semver": "1.13.1",
   "description": [
     "DirectML is a high-performance, hardware-accelerated DirectX 12 library for machine learning.",
     "DirectML provides GPU acceleration for common machine learning tasks across a broad range of supported hardware and drivers, ",

--- a/test/azure-port-arm64-windows.txt
+++ b/test/azure-port-arm64-windows.txt
@@ -1,2 +1,3 @@
 libdispatch
 tensorflow-lite
+onnxruntime[directml]

--- a/test/azure-port-arm64-windows.txt
+++ b/test/azure-port-arm64-windows.txt
@@ -1,3 +1,2 @@
 libdispatch
 tensorflow-lite
-onnxruntime[directml]

--- a/test/azure-port-linux.txt
+++ b/test/azure-port-linux.txt
@@ -1,2 +1,2 @@
 tensorflow-lite[gpu]
-onnxruntime[xnnpack,training]
+onnxruntime[xnnpack,training,directml]

--- a/test/azure-port-linux.txt
+++ b/test/azure-port-linux.txt
@@ -1,2 +1,2 @@
 tensorflow-lite[gpu]
-onnxruntime[xnnpack,training,directml]
+onnxruntime[xnnpack,training]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -25,7 +25,7 @@
       "port-version": 0
     },
     "directml": {
-      "baseline": "1.13.0",
+      "baseline": "1.13.1",
       "port-version": 0
     },
     "dlpack": {

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c7c353127b49639c59447823eae6f3e45e44ab20",
+      "git-tree": "aa4bc85c9d05b6aecb312b23f26f9d3c5014f5c8",
       "version-semver": "1.13.1",
       "port-version": 0
     },

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7c353127b49639c59447823eae6f3e45e44ab20",
+      "version-semver": "1.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8621fdac36cd2db3cea051d27b8b2e8eb8dfb33",
       "version-semver": "1.13.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Add check of `x64-xbox-scarlett` in the portfile.cmake

### References

* https://www.nuget.org/packages/Microsoft.AI.DirectML/
* https://microsoft.github.io/DirectML/

### Triplet Support

* `x64-windows`
* `arm64ec-windows`
* `x64-xbox-scarlett`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "directml"
            ],
            "baseline": "..."
        }
    ]
}
```
