### PR TITLE
[nvidia-cutlass] update to v3.4.1

### DIFF
--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIA/cutlass
-    REF v3.4.0
-    SHA512 6debdfa0ffbb9c14293619a281e864ac16592f64856e4a54ae456a79cbce3ec2f5068031f4eae589e72fb10c3c61f1fa6d3fa14650754a27c4b12e14774e7f75
+    REF v3.4.1
+    SHA512 c2ff60af28de951cf4420b163ba2dfc46d30c98fe9e6e765cd1e0be89bf9292e057542ec7061c043c42225b74d970f95f675d366db64105a5c103bb165183ab5
     PATCHES
         fix-cmake.patch
     HEAD_REF main

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nvidia-cutlass",
-  "version-semver": "3.4.0",
+  "version-semver": "3.4.1",
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -93,7 +93,7 @@
       "port-version": 0
     },
     "nvidia-cutlass": {
-      "baseline": "3.4.0",
+      "baseline": "3.4.1",
       "port-version": 0
     },
     "nvidia-tools-extension-sdk": {

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "840134ac751b910e02ce83656a78fdedcebfb456",
+      "version-semver": "3.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "75c26a2bd20f4cbd49b9ed5189b9eb2a21e30007",
       "version-semver": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

...

### References

* https://github.com/NVIDIA/cutlass/releases/tag/v3.4.1

### Triplet Support

* `x64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "nvidia-cutlass"
            ],
            "baseline": "..."
        }
    ]
}
```
