### PR TITLE
[nvidia-nvbench] Create a new port with latest commit

### DIFF
--- a/ports/nvidia-nvbench/fix-cmake.patch
+++ b/ports/nvidia-nvbench/fix-cmake.patch
@@ -1,0 +1,99 @@
+diff --git a/cmake/NVBenchConfigTarget.cmake b/cmake/NVBenchConfigTarget.cmake
+index 5e5e270..6032918 100644
+--- a/cmake/NVBenchConfigTarget.cmake
++++ b/cmake/NVBenchConfigTarget.cmake
+@@ -74,6 +74,11 @@ target_compile_options(nvbench.build_interface INTERFACE
+   $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--display_error_number>
+   $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Wno-deprecated-gpu-targets>
+ )
++if (WIN32)
++  target_compile_definitions(nvbench.build_interface INTERFACE
++    _USE_MATH_DEFINES
++  )
++endif()
+ if (NVBench_ENABLE_WERROR)
+   target_compile_options(nvbench.build_interface INTERFACE
+     $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--promote_warnings>
+diff --git a/cmake/NVBenchDependencies.cmake b/cmake/NVBenchDependencies.cmake
+index 78fa758..e4a91fe 100644
+--- a/cmake/NVBenchDependencies.cmake
++++ b/cmake/NVBenchDependencies.cmake
+@@ -1,48 +1,18 @@
+ ################################################################################
+ # fmtlib/fmt
+-include("${rapids-cmake-dir}/cpm/fmt.cmake")
++find_package(fmt CONFIG REQUIRED)
+ 
+ if(NOT BUILD_SHARED_LIBS AND NVBench_ENABLE_INSTALL_RULES)
+ set(export_set_details BUILD_EXPORT_SET nvbench-targets
+                        INSTALL_EXPORT_SET nvbench-targets)
+ endif()
+ 
+-rapids_cpm_fmt(${export_set_details}
+-  CPM_ARGS
+-    OPTIONS
+-      # Force static to keep fmt internal.
+-      "BUILD_SHARED_LIBS OFF"
+-)
+ 
+-if(NOT fmt_ADDED)
+-  set(fmt_is_external TRUE)
+-endif()
++set(fmt_is_external TRUE) # from vcpkg
+ 
+ ################################################################################
+ # nlohmann/json
+-#
+-# Following recipe from
+-# http://github.com/cpm-cmake/CPM.cmake/blob/master/examples/json/CMakeLists.txt
+-# Download the zips because the repo takes an excessively long time to clone.
+-rapids_cpm_find(nlohmann_json 3.9.1
+-  # Release:
+-  CPM_ARGS
+-    URL https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip
+-    URL_HASH SHA256=6bea5877b1541d353bd77bdfbdb2696333ae5ed8f9e8cc22df657192218cad91
+-    PATCH_COMMAND
+-      # Work around compiler bug in nvcc 11.0, see NVIDIA/NVBench#18
+-      ${CMAKE_COMMAND} -E copy
+-        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/nlohmann_json.hpp"
+-        "./include/nlohmann/json.hpp"
+-
+-  # Development version:
+-  # I'm waiting for https://github.com/nlohmann/json/issues/2676 to be fixed,
+-  # leave this in to simplify testing patches as they come out.
+-  #  CPM_ARGS
+-  #    VERSION develop
+-  #    URL https://github.com/nlohmann/json/archive/refs/heads/develop.zip
+-  #    OPTIONS JSON_MultipleHeaders ON
+-)
++find_package(nlohmann_json CONFIG REQUIRED)
+ 
+ add_library(nvbench_json INTERFACE IMPORTED)
+ if (TARGET nlohmann_json::nlohmann_json)
+diff --git a/cmake/NVBenchInstallRules.cmake b/cmake/NVBenchInstallRules.cmake
+index 16e9b7e..a475631 100644
+--- a/cmake/NVBenchInstallRules.cmake
++++ b/cmake/NVBenchInstallRules.cmake
+@@ -55,8 +55,10 @@ endif()
+ function(nvbench_install_libraries)
+   if(NVBench_ENABLE_INSTALL_RULES)
+     install(TARGETS ${ARGN}
+-      DESTINATION "${NVBench_INSTALL_LIB_DIR}"
+       EXPORT nvbench-targets
++      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     )
+   endif()
+ endfunction()
+diff --git a/cmake/NVBenchRapidsCMake.cmake b/cmake/NVBenchRapidsCMake.cmake
+index b110ccc..a6a5e00 100644
+--- a/cmake/NVBenchRapidsCMake.cmake
++++ b/cmake/NVBenchRapidsCMake.cmake
+@@ -21,5 +21,5 @@ endmacro()
+ macro(nvbench_init_rapids_cmake)
+   rapids_cmake_build_type(Release)
+   rapids_cmake_write_version_file("${NVBench_BINARY_DIR}/nvbench/detail/version.cuh")
+-  rapids_cpm_init()
++  # rapids_cpm_init() # vcpkg will be used
+ endmacro()

--- a/ports/nvidia-nvbench/portfile.cmake
+++ b/ports/nvidia-nvbench/portfile.cmake
@@ -1,0 +1,44 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH RAPIDS_SOURCE_PATH
+    REPO rapidsai/rapids-cmake
+    REF v24.02.00
+    SHA512 d9701353e7a11c339ed11e9867ca22fc937ef399820960bc8c4f4a8a78efa7a24e2ff46080b3ac6ff84cfd3c34780331d8c9a4aeaf4ccee565e3953260bb37ae
+    HEAD_REF main
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/nvbench
+    REF d8dced8a64d9ce305add92fa6d274fd49b569b7e
+    SHA512 ff9b8379b7e0d39f31d0635a15bfcbf818592c4e8e85471592a6b50407a74088f4cfe9c7876009b1ef99693a4a4d380815af1505a2e9d413662087f6da46ec10
+    PATCHES
+        fix-cmake.patch
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-Drapids-cmake-dir:PATH=${RAPIDS_SOURCE_PATH}/rapids-cmake"
+        "-DCMAKE_MODULE_PATH:PATH=${RAPIDS_SOURCE_PATH}/rapids-cmake"
+        -DNVBench_ENABLE_NVML=ON
+        -DNVBench_ENABLE_CUPTI=ON
+        -DNVBench_ENABLE_INSTALL_RULES=ON
+        -DNVBench_ENABLE_EXAMPLES=OFF
+        -DNVBench_ENABLE_WERROR=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/nvbench PACKAGE_NAME nvbench)
+
+vcpkg_copy_tools(TOOL_NAMES nvbench-ctl AUTO_CLEAN)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nvidia-nvbench/vcpkg.json
+++ b/ports/nvidia-nvbench/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "nvidia-nvbench",
+  "version-date": "2024-01-13",
+  "description": "CUDA Kernel Benchmarking Library",
+  "homepage": "https://github.com/NVIDIA/nvbench",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "cuda",
+    "fmt",
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/test/self-hosted-cuda.json
+++ b/test/self-hosted-cuda.json
@@ -15,6 +15,7 @@
     },
     "nvidia-cnmem",
     "nvidia-cutlass",
+    "nvidia-nvbench",
     "nvidia-tools-extension-sdk",
     "nvidia-triton-common",
     "nvidia-triton-core",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -96,6 +96,10 @@
       "baseline": "3.4.1",
       "port-version": 0
     },
+    "nvidia-nvbench": {
+      "baseline": "2024-01-13",
+      "port-version": 0
+    },
     "nvidia-tools-extension-sdk": {
       "baseline": "3.1.0",
       "port-version": 0

--- a/versions/n-/nvidia-nvbench.json
+++ b/versions/n-/nvidia-nvbench.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ea2e382bd110cc20157e3b48adc8631cde87d2d5",
+      "version-date": "2024-01-13",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create a new port from https://github.com/NVIDIA/nvbench

### References

* https://github.com/NVIDIA/nvbench
* The project uses CMake scripts from https://github.com/rapidsai/rapids-cmake

### Triplet Support

* `x64-windows`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "nvidia-nvbench"
            ],
            "baseline": "..."
        }
    ]
}
```
