### PR TITLE
[d3d12-transition-layer,winpixeventruntime] Support `pix` feature

### DIFF
--- a/ports/d3d12-transition-layer/fix-vcpkg.patch
+++ b/ports/d3d12-transition-layer/fix-vcpkg.patch
@@ -69,3 +69,31 @@ index e9d9537..8180fe1 100644
 +install(FILES ${INC} ${INL} ../include/XPlatHelpers.h
 +    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/D3D12TranslationLayer
 +)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4910b81..0d6cbf2 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -115,15 +115,18 @@ else()
+ 	target_compile_definitions(d3d12translationlayer PRIVATE DYNAMIC_LOAD_DXCORE=1)
+ endif()
+ 
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../packages.config ${CMAKE_CURRENT_BINARY_DIR}/packages.config COPYONLY)
+-add_library(WinPixEventRuntime INTERFACE IMPORTED GLOBAL)
+-set_target_properties(WinPixEventRuntime PROPERTIES INTERFACE_LINK_LIBRARIES "${CMAKE_BINARY_DIR}/packages/WinPixEventRuntime.1.0.190604001/build/WinPixEventRuntime.targets")
+-target_link_libraries(d3d12translationlayer WinPixEventRuntime)
+-
+ target_compile_definitions(d3d12translationlayer PRIVATE $<$<CONFIG:DEBUG>:DBG>)
+ target_compile_definitions(d3d12translationlayer PUBLIC $<$<CONFIG:DEBUG>:TRANSLATION_LAYER_DBG=1>)
+ 
+ if (USE_PIX)
++	find_path(PIX_INCLUDE_DIR NAMES "pix3.h" PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/WinPixEventRuntime" REQUIRED)
++	find_path(PIX_LIBRARY NAMES WinPixEventRuntime REQUIRED)
++	add_library(WinPixEventRuntime INTERFACE IMPORTED GLOBAL)
++	set_target_properties(WinPixEventRuntime PROPERTIES
++		INTERFACE_INCLUDE_DIRECTORIES "${PIX_INCLUDE_DIR}"
++		INTERFACE_LINK_LIBRARIES "${PIX_LIBRARY}"
++	)
++	target_link_libraries(d3d12translationlayer WinPixEventRuntime)
+ 	target_compile_definitions(d3d12translationlayer PUBLIC USE_PIX)
+ endif()
+ 

--- a/ports/d3d12-transition-layer/portfile.cmake
+++ b/ports/d3d12-transition-layer/portfile.cmake
@@ -5,22 +5,26 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/D3D12TranslationLayer
-    REF 283fe2eb00d75a3e4b59d935f486fffa4eac0b4d
-    SHA512 837c8f520ffee924e11a843ab9353ed8d27ff54e2f7c746fe771e1d955637430fd351f6020594fa4b9340270d4b9c0472d37780bbe174444b05e0a48a65d7805
+    REF 1666438638012549dbaf959f921bca2aeff5c550
+    SHA512 27e6ea47fab94df198b862b7dd6e97bc120ca873c4f18e639de6f69c0e4fecd4f46f9b742ec7aac106182b9c05903e71ae641cf8f83202f4cebf02ac2200b808
     PATCHES
         fix-vcpkg.patch
     HEAD_REF master
+)
+file(REMOVE "${SOURCE_PATH}/external/d3dx12.h" "${SOURCE_PATH}/external/d3d12compatibility.h")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        pix  USE_PIX
+        wdk  HAS_WDK
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     WINDOWS_USE_MSBUILD
-    OPTIONS
-        -DUSE_PIX=OFF
-        -DHAS_WDK=OFF
+    OPTIONS ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
-vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/d3d12-transition-layer/vcpkg.json
+++ b/ports/d3d12-transition-layer/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "d3d12-transition-layer",
-  "version-date": "2023-12-13",
+  "version-date": "2024-03-18",
   "description": "A library containing utilities for mapping higher-level graphics work to D3D12",
   "homepage": "https://github.com/microsoft/D3D12TranslationLayer",
   "license": "MIT",
   "supports": "windows",
   "dependencies": [
+    "atl",
     {
       "name": "directx-headers",
       "version>=": "1.610.0"
@@ -14,5 +15,13 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "pix": {
+      "description": "Enable the use of PIX markers",
+      "dependencies": [
+        "winpixeventruntime"
+      ]
+    }
+  }
 }

--- a/ports/winpixeventruntime/portfile.cmake
+++ b/ports/winpixeventruntime/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+vcpkg_find_acquire_program(NUGET)
+
+set(ENV{NUGET_PACKAGES} "${BUILDTREES_DIR}/nuget")
+
+# https://devblogs.microsoft.com/pix/pix-2403/
+# see https://www.nuget.org/packages/WinPixEventRuntime/
+set(PACKAGE_NAME    "WinPixEventRuntime")
+set(PACKAGE_VERSION "1.0.231030001")
+
+file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}")
+vcpkg_execute_required_process(
+    COMMAND ${NUGET} install "${PACKAGE_NAME}" -Version "${PACKAGE_VERSION}" -Verbosity detailed
+                -OutputDirectory "${CURRENT_BUILDTREES_DIR}"
+    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+    LOGNAME install-nuget
+)
+
+get_filename_component(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}.${PACKAGE_VERSION}" ABSOLUTE)
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(NOT ((VCPKG_TARGET_ARCHITECTURE STREQUAL "x64") OR (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")))
+        message(WARNING "The architecture '${VCPKG_TARGET_ARCHITECTURE}' is not expected")
+    endif()
+else()
+    message(FATAL_ERROR "The triplet '${TARGET_TRIPLET}' is not supported")
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL "${SOURCE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/WinPixEventRuntime.lib"       DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${SOURCE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/WinPixEventRuntime.dll"       DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${SOURCE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/WinPixEventRuntime_UAP.lib"   DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${SOURCE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/WinPixEventRuntime_UAP.dll"   DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+else()
+    message(FATAL_ERROR "The target platform is not supported")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${SOURCE_PATH}/ThirdPartyNotices.txt"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/winpixeventruntime/vcpkg.json
+++ b/ports/winpixeventruntime/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "winpixeventruntime",
+  "version-semver": "1.0.231030001",
+  "description": "llows applications to be instrumented with marker events, for use with Microsoft PIX.",
+  "homepage": "https://devblogs.microsoft.com/pix/winpixeventruntime/",
+  "license": null,
+  "supports": "windows & (x64 | arm64)"
+}

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -7,6 +7,13 @@
   "supports": "windows",
   "dependencies": [
     {
+      "name": "d3d12-transition-layer",
+      "features": [
+        "pix"
+      ],
+      "platform": "x64 & windows"
+    },
+    {
       "name": "winpixeventruntime",
       "platform": "x64 & windows"
     },

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -7,6 +7,10 @@
   "supports": "windows",
   "dependencies": [
     {
+      "name": "winpixeventruntime",
+      "platform": "x64 & windows"
+    },
+    {
       "name": "onnxruntime",
       "features": [
         "openvino",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,7 +21,7 @@
       "port-version": 0
     },
     "d3d12-transition-layer": {
-      "baseline": "2023-12-13",
+      "baseline": "2024-03-18",
       "port-version": 0
     },
     "directml": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -168,6 +168,10 @@
       "baseline": "2022-05-14",
       "port-version": 0
     },
+    "winpixeventruntime": {
+      "baseline": "1.0.231030001",
+      "port-version": 0
+    },
     "xatlas": {
       "baseline": "2023-11-07",
       "port-version": 0

--- a/versions/d-/d3d12-transition-layer.json
+++ b/versions/d-/d3d12-transition-layer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94f885dd1ee8333f577734e3f6f2260c685001e4",
+      "version-date": "2024-03-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd9abec7585b29947948b84a8ff636877b8f734b",
       "version-date": "2023-12-13",
       "port-version": 0

--- a/versions/w-/winpixeventruntime.json
+++ b/versions/w-/winpixeventruntime.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "45169fcf58e8790c6f3b27c422f345bfc8d55b8d",
+      "version-semver": "1.0.231030001",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

* `winpixeventruntime`: Create a new port with latest NuGet version
* `d3d12-transition-layer`: Support feature `pix` which uses `winpixeventruntime`

### References

* https://github.com/microsoft/D3D12TranslationLayer
* https://devblogs.microsoft.com/pix/winpixeventruntime/

### Triplet Support

* `x64-windows`
* `arm64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "winpixeventruntime",
                {
                  "name": "d3d12-transition-layer",
                  "features": [
                    "pix"
                  ]
                }
            ],
            "baseline": "..."
        }
    ]
}
```
