### PR TITLE
[liblzma] Create a new port with v5.4.6

### DIFF
--- a/.circleci/port-linux.txt
+++ b/.circleci/port-linux.txt
@@ -2,3 +2,4 @@ protobuf
 grpc[codegen]
 flatbuffers
 abseil
+liblzma

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -1,0 +1,59 @@
+# https://sourceforge.net/projects/lzmautils/
+# https://sourceforge.net/projects/lzmautils/files/xz-5.4.6.tar.xz/download
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lzmautils
+    FILENAME xz-5.4.6.tar.xz
+    SHA512 495cc890d25c075c927c907b77e60d86dd8a4c377cea5b1172c8e916984149a7bb5fb32db25091f7219346b83155b47e4bc0404cc8529d992014cd7ed0c278b7
+)
+
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    # https://cmake.org/cmake/help/latest/module/FindLibLZMA.html
+    message(WARNING "Forcing system built-in LibLZMA")
+    message(STATUS "Installing LibLZMA headers")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    file(INSTALL "${SOURCE_PATH}/src/liblzma/api/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(REMOVE
+        "${CURRENT_PACKAGES_DIR}/include/Makefile.am"
+        "${CURRENT_PACKAGES_DIR}/include/Makefile.in"
+    )
+    return()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DCREATE_XZ_SYMLINKS=OFF
+        -DCREATE_LZMA_SYMLINKS=OFF
+        -DENABLE_SMALL=${VCPKG_TARGET_IS_ANDROID}
+        -DHAVE_GETOPT_LONG=OFF
+    MAYBE_UNUSED_VARIABLES
+        CREATE_XZ_SYMLINKS
+        CREATE_LZMA_SYMLINKS
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_fixup_pkgconfig()
+endif()
+# https://cmake.org/cmake/help/latest/module/FindLibLZMA.html
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/liblzma PACKAGE_NAME liblzma)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endif()
+
+file(INSTALL "${SOURCE_PATH}/README" "${SOURCE_PATH}/THANKS"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "liblzma",
+  "version": "5.4.6",
+  "description": "Compression library with an API similar to that of zlib.",
+  "homepage": "https://sourceforge.net/projects/lzmautils/",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows",
   "dependencies": [
+    "liblzma",
     {
       "name": "d3d12-transition-layer",
       "features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -68,6 +68,10 @@
       "baseline": "swift-5.10",
       "port-version": 0
     },
+    "liblzma": {
+      "baseline": "5.4.6",
+      "port-version": 0
+    },
     "llama-cpp": {
       "baseline": "b1695",
       "port-version": 0

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a990dde00453701a6f899ee6741033b4c6f9e2fb",
+      "version": "5.4.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Hotfix to prevent failure related to port `liblzma` 

### References

* https://sourceforge.net/projects/liblzma/
* https://github.com/xz-mirror/xz
* https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/
* https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27
* https://jfrog.com/blog/xz-backdoor-attack-cve-2024-3094-all-you-need-to-know/

### Triplet Support

For now, major triplets are in concern

* `x64-windows`
* `x64-linux`
* `x64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "liblzma"
            ],
            "baseline": "..."
        }
    ]
}
```
