### PR TITLE
[fp16] Update to later version

### DIFF
--- a/ports/fp16/portfile.cmake
+++ b/ports/fp16/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Maratyszcza/fp16
+    REF 581ac1c79dd9d9f6f4e8b2934e7a55c7becf0799
+    SHA512 a7898d9fe4ae183562c87b3e61865b1166dd45ab342f6874a42ec8123f8cf41c0074df0bce7696d378c364ff5f363d33942f12c63d804efacb7423b64f3c10f4
+)
+
+file(INSTALL    "${SOURCE_PATH}/include/fp16.h"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
+file(INSTALL    "${SOURCE_PATH}/include/fp16/fp16.h"
+                "${SOURCE_PATH}/include/fp16/bitcasts.h"
+                "${SOURCE_PATH}/include/fp16/psimd.h"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/fp16"
+)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fp16/vcpkg.json
+++ b/ports/fp16/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "fp16",
+  "version-date": "2024-04-11",
+  "description": "Header-only library for conversion to/from half-precision floating point formats",
+  "homepage": "https://github.com/Maratyszcza/FP16",
+  "dependencies": [
+    "psimd"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -52,6 +52,10 @@
       "baseline": "1.0",
       "port-version": 3
     },
+    "fp16": {
+      "baseline": "2024-04-11",
+      "port-version": 0
+    },
     "gemmlowp": {
       "baseline": "2022-02-09",
       "port-version": 1

--- a/versions/f-/fp16.json
+++ b/versions/f-/fp16.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b92ec719d5b81f3b053a82b9350c9e5d1a2b7fa9",
+      "version-date": "2024-04-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Update to the latest commit

### References

* https://github.com/Maratyszcza/FP16/commit/581ac1c79dd9d9f6f4e8b2934e7a55c7becf0799

### Triplet Support

All triplets in the registry

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "fp16"
            ],
            "baseline": "..."
        }
    ]
}
```
