### PR TITLE
[onnxruntime] Fix more CI failures

### DIFF
--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -45,6 +45,16 @@ jobs:
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
 
+      - uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: "C:/vcpkg"
+          vcpkgGitCommitId: "943c5ef1c8f6b5e6ced092b242c8299caae2ff01" # 2024.04.26
+          vcpkgJsonGlob: "test/vcpkg.json"
+          runVcpkgInstall: true
+          runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
+        env:
+          VCPKG_DEFAULT_TRIPLET: "arm64-windows"
+
       - uses: yumis-coconudge/clean-workspace-action@v1.0.5
         with:
           additional-path: "C:/vcpkg/installed"

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -100,9 +100,6 @@
         }
       ]
     },
-    "tensorrt": {
-      "description": "Build with NVIDIA TensorRT support"
-    },
     "xnnpack": {
       "description": "Build with XNNPack support",
       "dependencies": [

--- a/test/azure-port-arm64-windows.txt
+++ b/test/azure-port-arm64-windows.txt
@@ -1,3 +1,2 @@
 libdispatch
 tensorflow-lite
-onnxruntime[xnnpack,directml]

--- a/test/self-hosted-cuda.json
+++ b/test/self-hosted-cuda.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2024-02-12",
+  "version-date": "2024-05-13",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows",
@@ -10,6 +10,13 @@
       "name": "llama-cpp",
       "features": [
         "cublas"
+      ],
+      "platform": "x64 & windows"
+    },
+    {
+      "name": "onnxruntime",
+      "features": [
+        "cuda"
       ],
       "platform": "x64 & windows"
     },

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -27,6 +27,14 @@
         "xnnpack"
       ],
       "platform": "x64 & windows"
+    },
+    {
+      "name": "onnxruntime",
+      "features": [
+        "directml",
+        "xnnpack"
+      ],
+      "platform": "arm64 & windows"
     }
   ]
 }

--- a/triplets/x64-linux.cmake
+++ b/triplets/x64-linux.cmake
@@ -5,6 +5,7 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_LIBRARY_LINKAGE static)
 list(APPEND dynamic_library_ports
     angle # expect libEGL.so, libGLESv2.so
+    xnnpack
 )
 foreach(p IN ITEMS ${dynamic_library_ports})
     if(PORT STREQUAL "${p}")


### PR DESCRIPTION
### Changes

* Remove `tensorrt` feature. Will be resurrected in later port version
* Make `libXNNPACK.so` in Linux build to prevent undefined symbol error

Can't get the correct reason...

### References

* #192

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`
* `arm64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "onnxruntime"
            ],
            "baseline": "..."
        }
    ]
}
```
