### PR TITLE
[miniaudio] Update to 0.11.21

### DIFF
--- a/ports/miniaudio/portfile.cmake
+++ b/ports/miniaudio/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mackron/miniaudio
-    REF 0.11.18
-    SHA512 3e4a08c326f1a3e8beef962fcb525739734b22572857fe5323d2e72c3e1890edd5d26d3e1264ca5e8ad1c691fb5c312cfb9d1f09484c72353c92b20619c9f678
+    REF 0.11.21
+    SHA512 0c67ff7d9112409fea5af7756c1bc14bca4acfa45a97896ea339cdab228ac3dcc843c492e6da9dc75d4cd6f6b795ee80fe3ad9c4c746d7db691b1216f86e456d
 )
 
 # Build as a C++ or Objective-C++. Not in C language

--- a/ports/miniaudio/vcpkg.json
+++ b/ports/miniaudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "miniaudio",
-  "version": "0.11.18",
+  "version": "0.11.21",
   "description": "Audio playback and capture library written in C, in a single source file",
   "homepage": "https://github.com/mackron/miniaudio",
   "license": "MIT",

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -100,6 +100,7 @@
       "name": "vcpkg-cmake",
       "host": true
     },
+    "miniaudio",
     "xatlas",
     "zlib-ng"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -85,7 +85,7 @@
       "port-version": 0
     },
     "miniaudio": {
-      "baseline": "0.11.18",
+      "baseline": "0.11.21",
       "port-version": 0
     },
     "ml-dtypes": {

--- a/versions/m-/miniaudio.json
+++ b/versions/m-/miniaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f0584e9d78239e8bb2b1d034d8051095abcca68",
+      "version": "0.11.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "b1a0deaf0d285a00fa16e7a84419401bb891b38a",
       "version": "0.11.18",
       "port-version": 0


### PR DESCRIPTION
### Changes

Update to latest Git tag 0.11.21

### References

* https://github.com/mackron/miniaudio/releases/tag/0.11.21

### Triplet Support

* `x64-windows`
* `x64-osx`
* `arm64-ios`
* `x64-linux`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "miniaudio"
            ],
            "baseline": "..."
        }
    ]
}
```
