### PR TITLE
[openjdk] Create a new port with jdk-23+10

### DIFF
--- a/ports/openjdk/linux-setup.cmake
+++ b/ports/openjdk/linux-setup.cmake
@@ -1,0 +1,23 @@
+# choco install zip
+find_program(ZIP NAMES zip REQUIRED)
+message(STATUS "Using zip: ${ZIP}")
+
+find_program(BASH NAMES bash REQUIRED)
+message(STATUS "Using bash: ${BASH}")
+
+find_program(MAKE NAMES make REQUIRED)
+message(STATUS "Using make: ${MAKE}")
+
+# OpenJDK 21 from https://learn.microsoft.com/en-us/java/openjdk/download
+vcpkg_download_distfile(MICROSOFT_JDK_21_PATH
+    URLS "https://aka.ms/download-jdk/microsoft-jdk-21.0.2-linux-x64.tar.gz"
+    FILENAME microsoft-jdk-21.0.2-linux-x64.tar.gz
+    SHA512 3e94145d956558184c23023e84486337e853901953b5b927162ddd039529ebfd8ef664491dda1573c5ca4d3d3d8161fffaef8630702dd3a2b706212ab1405da3
+)
+file(ARCHIVE_EXTRACT INPUT "${MICROSOFT_JDK_21_PATH}" DESTINATION "${CURRENT_BUILDTREES_DIR}")
+get_filename_component(BOOTJDK_PATH "${CURRENT_BUILDTREES_DIR}/jdk-21.0.2+13" ABSOLUTE)
+
+list(APPEND CONFIG_TOOLCHAIN_OPTIONS
+    "--with-toolchain-type=gcc"
+    "--with-stdc++lib=${VCPKG_CRT_LINKAGE}" # dynamic, static, default        
+)

--- a/ports/openjdk/portfile.cmake
+++ b/ports/openjdk/portfile.cmake
@@ -1,0 +1,116 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY) 
+
+# See https://openjdk.org/groups/build/doc/building.html or doc/building.md
+# Prepare toolchains like BASH, MAKE, and BOOTJDK_PATH...
+if(VCPKG_TARGET_IS_WINDOWS)
+    include(${CMAKE_CURRENT_LIST_DIR}/windows-setup.cmake)
+elseif(VCPKG_TARGET_IS_LINUX)
+    include(${CMAKE_CURRENT_LIST_DIR}/linux-setup.cmake)
+endif()
+if(NOT DEFINED BOOTJDK_PATH)
+    message(FATAL_ERROR "BOOTJDK_PATH is required")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO openjdk/jdk
+    REF jdk-23+10
+    SHA512 cccb0150c3662426a668b11f3d4b0652df53a421c39a42d88fc177f25f04df0ced6cb7ba5e47a44edb79d13d1677ca5877e066b2f98a7edac49ed7975fa61736
+    HEAD_REF master
+)
+
+# for command debugging of `configure`
+vcpkg_execute_required_process(
+    COMMAND ${BASH} configure --help
+    LOGNAME configure-help-${TARGET_TRIPLET}
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+)
+
+set(BUILD_DIR_DBG "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+set(BUILD_DIR_REL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+
+file(REMOVE_RECURSE "${BUILD_DIR_DBG}" "${BUILD_DIR_REL}")
+get_filename_component(SOURCE_DIR_NAME "${SOURCE_PATH}" NAME)
+file(COPY "${SOURCE_PATH}" DESTINATION "${CURRENT_BUILDTREES_DIR}")
+file(RENAME "${CURRENT_BUILDTREES_DIR}/${SOURCE_DIR_NAME}" "${BUILD_DIR_DBG}")
+file(COPY "${SOURCE_PATH}" DESTINATION "${CURRENT_BUILDTREES_DIR}")
+file(RENAME "${CURRENT_BUILDTREES_DIR}/${SOURCE_DIR_NAME}" "${BUILD_DIR_REL}")
+
+# todo: replace zip, freetype, etc
+
+message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
+vcpkg_execute_required_process(
+    COMMAND ${BASH} configure
+        "--prefix=${CURRENT_PACKAGES_DIR}/debug"
+        "--exec-prefix=${CURRENT_PACKAGES_DIR}/debug"
+        "--enable-debug" # replaces "--with-debug-level=fastdebug"
+        "--with-version-string=23+10"
+        "--with-boot-jdk=${BOOTJDK_PATH}"
+        "--with-jvm-variants=server" # client, minimal, etc
+        "--with-target-bits=64"
+        "--with-source-date=version"
+        "--with-build-user=vcpkg"
+        ${CONFIG_TOOLCHAIN_OPTIONS}
+    LOGNAME config-${TARGET_TRIPLET}-dbg
+    WORKING_DIRECTORY "${BUILD_DIR_DBG}"
+)
+
+# for command debugging of `make`
+vcpkg_execute_required_process(
+    COMMAND ${MAKE} help
+    LOGNAME make-help-${BUILD_DIR_DBG}-dbg
+    WORKING_DIRECTORY "${BUILD_DIR_DBG}"
+)
+
+message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+vcpkg_execute_required_process(
+    COMMAND ${MAKE} JOBS=${VCPKG_CONCURRENCY} LOG=info
+        images docs # all
+    LOGNAME build-${TARGET_TRIPLET}-dbg
+    WORKING_DIRECTORY "${BUILD_DIR_DBG}"
+)
+
+message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
+vcpkg_execute_required_process(
+    COMMAND ${BASH} configure
+        "--prefix=${CURRENT_PACKAGES_DIR}"
+        "--exec-prefix=${CURRENT_PACKAGES_DIR}"
+        "--with-version-string=23+10"
+        "--with-boot-jdk=${BOOTJDK_PATH}"
+        "--with-jvm-variants=server" # client, minimal, etc
+        "--with-target-bits=64"
+        "--with-source-date=version"
+        "--with-build-user=vcpkg"
+        ${CONFIG_TOOLCHAIN_OPTIONS}
+    LOGNAME config-${TARGET_TRIPLET}-rel
+    WORKING_DIRECTORY "${BUILD_DIR_REL}"
+)
+
+message(STATUS "Building ${TARGET_TRIPLET}-rel")
+vcpkg_execute_required_process(
+    COMMAND ${MAKE} JOBS=${VCPKG_CONCURRENCY} LOG=info
+        images docs
+    LOGNAME build-${TARGET_TRIPLET}-rel
+    WORKING_DIRECTORY "${BUILD_DIR_REL}"
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(OUTPUT_NAME "windows-x86_64-server-release")
+    get_filename_component(OUTPUT_DIR "${BUILD_DIR_REL}/build/${OUTPUT_NAME}/jdk" ABSOLUTE)
+    file(COPY "${OUTPUT_DIR}/" DESTINATION "${CURRENT_PACKAGES_DIR}")
+    include(${CMAKE_CURRENT_LIST_DIR}/windows-cleanup.cmake)
+elseif(VCPKG_TARGET_IS_LINUX)
+    include(${CMAKE_CURRENT_LIST_DIR}/linux-cleanup.cmake)
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/modules"
+    # ...
+)
+
+file(INSTALL "${SOURCE_PATH}/README.md"
+             "${SOURCE_PATH}/ADDITIONAL_LICENSE_INFO" 
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/openjdk/portfile.cmake
+++ b/ports/openjdk/portfile.cmake
@@ -4,8 +4,6 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 # Prepare toolchains like BASH, MAKE, and BOOTJDK_PATH...
 if(VCPKG_TARGET_IS_WINDOWS)
     include(${CMAKE_CURRENT_LIST_DIR}/windows-setup.cmake)
-elseif(VCPKG_TARGET_IS_LINUX)
-    include(${CMAKE_CURRENT_LIST_DIR}/linux-setup.cmake)
 endif()
 if(NOT DEFINED BOOTJDK_PATH)
     message(FATAL_ERROR "BOOTJDK_PATH is required")

--- a/ports/openjdk/vcpkg.json
+++ b/ports/openjdk/vcpkg.json
@@ -4,5 +4,5 @@
   "description": "JDK main-line development",
   "homepage": "https://openjdk.org/projects/jdk",
   "license": "GPL-2.0",
-  "supports": "windows"
+  "supports": "x64 & windows"
 }

--- a/ports/openjdk/vcpkg.json
+++ b/ports/openjdk/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "name": "openjdk-jdk",
+  "name": "openjdk",
   "version-string": "jdk-23+10",
   "description": "JDK main-line development",
   "homepage": "https://openjdk.org/projects/jdk",

--- a/ports/openjdk/vcpkg.json
+++ b/ports/openjdk/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "openjdk-jdk",
+  "version-string": "jdk-23+10",
+  "description": "JDK main-line development",
+  "homepage": "https://openjdk.org/projects/jdk",
+  "license": "GPL-2.0",
+  "supports": "windows"
+}

--- a/ports/openjdk/windows-cleanup.cmake
+++ b/ports/openjdk/windows-cleanup.cmake
@@ -1,0 +1,20 @@
+file(GLOB UNUSED_FILES
+    "${CURRENT_PACKAGES_DIR}/bin/api-ms*.dll"
+    "${CURRENT_PACKAGES_DIR}/bin/ucrtbase*.dll"
+    "${CURRENT_PACKAGES_DIR}/bin/vcruntime*.dll"
+    "${CURRENT_PACKAGES_DIR}/bin/msvc*.dll"
+    "${CURRENT_PACKAGES_DIR}/bin/*.map"
+    "${CURRENT_PACKAGES_DIR}/bin/*.pdb"
+    "${CURRENT_PACKAGES_DIR}/bin/server/*.map"
+    "${CURRENT_PACKAGES_DIR}/bin/server/*.pdb"
+    "${CURRENT_PACKAGES_DIR}/_optimize_image_exec*"
+    "${CURRENT_PACKAGES_DIR}/release"
+)
+file(REMOVE_RECURSE ${UNUSED_FILES})
+
+file(GLOB EXE_FILES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+foreach(EXE_FILE ${EXE_FILES})
+    get_filename_component(EXE_NAME "${EXE_FILE}" NAME_WE)
+    list(APPEND TOOLS ${EXE_NAME})
+endforeach()
+vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)

--- a/ports/openjdk/windows-setup.cmake
+++ b/ports/openjdk/windows-setup.cmake
@@ -1,0 +1,28 @@
+# choco install zip
+find_program(ZIP NAMES zip PATHS "C:/ProgramData/chocolatey/bin" REQUIRED)
+message(STATUS "Using zip: ${ZIP}")
+get_filename_component(ZIP_PATH "${ZIP}" PATH)
+vcpkg_add_to_path(PREPEND "${ZIP_PATH}")
+
+# vcpkg_acquire_msys(MSYS_ROOT PACKAGES bash autoconf make gzip unzip ..)
+vcpkg_acquire_msys(MSYS_ROOT Z_ALL_PACKAGES)
+vcpkg_add_to_path(PREPEND "${MSYS_ROOT}")
+vcpkg_add_to_path(PREPEND "${MSYS_ROOT}/usr/bin")
+find_program(BASH NAMES bash PATHS "${MSYS_ROOT}/usr/bin" REQUIRED NO_DEFAULT_PATH)
+message(STATUS "Using bash: ${BASH}")
+
+find_program(MAKE NAMES make PATHS "${MSYS_ROOT}/usr/bin" REQUIRED NO_DEFAULT_PATH)
+message(STATUS "Using make: ${MAKE}")
+
+# OpenJDK 21 from https://learn.microsoft.com/en-us/java/openjdk/download
+vcpkg_download_distfile(MICROSOFT_JDK_21_PATH
+    URLS "https://aka.ms/download-jdk/microsoft-jdk-21.0.2-windows-x64.zip"
+    FILENAME microsoft-jdk-21.0.2-windows-x64.zip
+    SHA512 e31c8d3fb6ff7e894b47b7faac3e1c13b959055dadba5f42025af541bf5ea7614b7088266e23d8774dcb7ea293d32f38378e59a6b79a9200e1502fa05f46d888
+)
+file(ARCHIVE_EXTRACT INPUT "${MICROSOFT_JDK_21_PATH}" DESTINATION "${CURRENT_BUILDTREES_DIR}")
+get_filename_component(BOOTJDK_PATH "${CURRENT_BUILDTREES_DIR}/jdk-21.0.2+13" ABSOLUTE)
+
+list(APPEND CONFIG_TOOLCHAIN_OPTIONS
+    "--with-toolchain-type=microsoft"
+)

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2024-02-24",
+  "version-date": "2024-05-18",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows",
   "dependencies": [
-    "liblzma",
     {
       "name": "d3d12-transition-layer",
       "features": [
@@ -14,15 +13,12 @@
       ],
       "platform": "x64 & windows"
     },
-    {
-      "name": "winpixeventruntime",
-      "platform": "x64 & windows"
-    },
+    "liblzma",
     {
       "name": "onnxruntime",
       "features": [
-        "openvino",
         "directml",
+        "openvino",
         "python",
         "xnnpack"
       ],
@@ -35,6 +31,14 @@
         "xnnpack"
       ],
       "platform": "arm64 & windows"
+    },
+    {
+      "name": "openjdk",
+      "platform": "x64 & windows"
+    },
+    {
+      "name": "winpixeventruntime",
+      "platform": "x64 & windows"
     }
   ]
 }

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2024-02-12",
+  "version-date": "2024-05-18",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows | linux | osx | ios",
@@ -19,14 +19,6 @@
       "platform": "osx | ios"
     },
     {
-      "name": "d3d12-transition-layer",
-      "platform": "windows"
-    },
-    {
-      "name": "opencl-on-dx12",
-      "platform": "windows"
-    },
-    {
       "name": "cpuinfo",
       "features": [
         "tools"
@@ -34,29 +26,13 @@
       "platform": "linux"
     },
     {
-      "name": "xnnpack",
-      "platform": "linux"
-    },
-    {
-      "name": "onnxruntime",
-      "features": [
-        "python"        
-      ],
+      "name": "d3d12-transition-layer",
       "platform": "windows"
-    },
-    {
-      "name": "onnxruntime",
-      "features": [
-        "xnnpack",
-        "framework",
-        "coreml"
-      ],
-      "platform": "osx"
     },
     "etcpak",
     {
-      "name": "openjdk",
-      "platform": "windows"
+      "name": "fbgemm",
+      "platform": "!arm"
     },
     {
       "name": "libdispatch",
@@ -77,9 +53,34 @@
       "name": "metal-cpp",
       "platform": "osx | ios"
     },
+    "miniaudio",
+    {
+      "name": "onnxruntime",
+      "features": [
+        "coreml",
+        "framework",
+        "xnnpack"
+      ],
+      "platform": "osx"
+    },
+    {
+      "name": "onnxruntime",
+      "features": [
+        "python"
+      ],
+      "platform": "windows"
+    },
     {
       "name": "opencl",
       "platform": "windows | linux"
+    },
+    {
+      "name": "opencl-on-dx12",
+      "platform": "windows"
+    },
+    {
+      "name": "openjdk",
+      "platform": "x64 & windows"
     },
     "openssl3",
     {
@@ -104,12 +105,11 @@
       "name": "vcpkg-cmake",
       "host": true
     },
-    {
-      "name": "fbgemm",
-      "platform": "!arm"
-    },
-    "miniaudio",
     "xatlas",
+    {
+      "name": "xnnpack",
+      "platform": "linux"
+    },
     "zlib-ng"
   ]
 }

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -55,6 +55,10 @@
     },
     "etcpak",
     {
+      "name": "openjdk",
+      "platform": "windows"
+    },
+    {
       "name": "libdispatch",
       "platform": "windows | android"
     },

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -78,10 +78,6 @@
       "name": "opencl-on-dx12",
       "platform": "windows"
     },
-    {
-      "name": "openjdk",
-      "platform": "x64 & windows"
-    },
     "openssl3",
     {
       "name": "openssl3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -144,6 +144,10 @@
       "baseline": "2023-12-14",
       "port-version": 0
     },
+    "openjdk": {
+      "baseline": "jdk-23+10",
+      "port-version": 0
+    },
     "openssl": {
       "baseline": "3.2.1",
       "port-version": 0

--- a/versions/o-/openjdk.json
+++ b/versions/o-/openjdk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c1117f1c72e18a3771acde0a11cfec79b7aa7331",
+      "version-string": "jdk-23+10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/o-/openjdk.json
+++ b/versions/o-/openjdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c1117f1c72e18a3771acde0a11cfec79b7aa7331",
+      "git-tree": "6a572f9bb56893885273b09fe82ca370ac229f36",
       "version-string": "jdk-23+10",
       "port-version": 0
     }

--- a/versions/o-/openjdk.json
+++ b/versions/o-/openjdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a572f9bb56893885273b09fe82ca370ac229f36",
+      "git-tree": "0837310487647e108bc1b4ec5cd40e088675e48e",
       "version-string": "jdk-23+10",
       "port-version": 0
     }


### PR DESCRIPTION
### Changes

Just for an experiment

### References

* https://openjdk.org/projects/jdk
* https://github.com/openjdk/jdk/tree/jdk-23%2B10

### Triplet Support

* `x64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "openjdk"
            ],
            "baseline": "..."
        }
    ]
}
```
