### PR TITLE
CI: More fixes after #199

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -56,7 +56,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-osx"
-          VCPKG_BINARY_SOURCES: "default;${{ secrets.VCPKG_BINARY_SOURCES }}"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
 
       - uses: lukka/run-vcpkg@v11.5
         with:
@@ -67,4 +67,4 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "arm64-osx"
-          VCPKG_BINARY_SOURCES: "default;${{ secrets.VCPKG_BINARY_SOURCES }}"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -26,7 +26,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/triplets
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
       - uses: ConorMacBride/install-package@v1.1.0
         with:
           brew: ninja autoconf automake libtool
@@ -40,7 +40,7 @@ jobs:
           mkdir -p ${VCPKG_DOWNLOADS}
           mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
 
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4.0.2
         with:
           key: "v2419-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
           path: |

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   overlay:
-    # check https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+    # check https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
@@ -25,7 +25,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.1
       - uses: ConorMacBride/install-package@v1.1.0
         with:
           apt: nuget nasm libnuma-dev libopenmpi-dev libx11-dev libxi-dev libxext-dev libx11-xcb-dev
@@ -38,7 +38,7 @@ jobs:
           VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
           VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-archives"
 
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4.0.0
         with:
           key: "v2419-x64-linux-${{ matrix.vcpkg_tag }}"
           path: |

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -54,6 +54,6 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-linux"
-          VCPKG_BINARY_SOURCES: "default;${{ secrets.VCPKG_BINARY_SOURCES }}"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
           VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
           VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-archives"

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
       - uses: ConorMacBride/install-package@v1.1.0
         with:
           apt: nuget nasm libnuma-dev libopenmpi-dev libx11-dev libxi-dev libxext-dev libx11-xcb-dev
@@ -38,7 +38,7 @@ jobs:
           VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
           VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-archives"
 
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4.0.2
         with:
           key: "v2419-x64-linux-${{ matrix.vcpkg_tag }}"
           path: |

--- a/.github/workflows/build-windows-cuda.yml
+++ b/.github/workflows/build-windows-cuda.yml
@@ -49,6 +49,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
 
       - uses: yumis-coconudge/clean-workspace-action@v1.0.6
         with:

--- a/.github/workflows/build-windows-cuda.yml
+++ b/.github/workflows/build-windows-cuda.yml
@@ -20,7 +20,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.1
       - uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
@@ -33,7 +33,7 @@ jobs:
           git config --system core.longpaths true
         shell: pwsh
 
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4.0.0
         with:
           key: "v2419-x64-windows-cuda"
           path: |
@@ -49,8 +49,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
-          VCPKG_BINARY_SOURCES: "default"
 
-      - uses: yumis-coconudge/clean-workspace-action@v1.0.6
+      - uses: yumis-coconudge/clean-workspace-action@v1
         with:
           additional-path: "C:/vcpkg/installed"

--- a/.github/workflows/build-windows-cuda.yml
+++ b/.github/workflows/build-windows-cuda.yml
@@ -20,7 +20,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
       - uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
@@ -33,7 +33,7 @@ jobs:
           git config --system core.longpaths true
         shell: pwsh
 
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4.0.2
         with:
           key: "v2419-x64-windows-cuda"
           path: |
@@ -50,6 +50,6 @@ jobs:
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
 
-      - uses: yumis-coconudge/clean-workspace-action@v1
+      - uses: yumis-coconudge/clean-workspace-action@v1.0.6
         with:
           additional-path: "C:/vcpkg/installed"

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -19,7 +19,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.1
       - uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
@@ -32,7 +32,7 @@ jobs:
           git config --system core.longpaths true
         shell: pwsh
 
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4.0.0
         with:
           key: "v2419-x64-windows-hosted"
           path: |
@@ -48,7 +48,6 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
-          VCPKG_BINARY_SOURCES: "default"
 
       - uses: lukka/run-vcpkg@v11.5
         with:
@@ -59,8 +58,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "arm64-windows"
-          VCPKG_BINARY_SOURCES: "default"
 
-      - uses: yumis-coconudge/clean-workspace-action@v1.0.6
+      - uses: yumis-coconudge/clean-workspace-action@v1.0.5
         with:
           additional-path: "C:/vcpkg/installed"

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -48,6 +48,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
 
       - uses: lukka/run-vcpkg@v11.5
         with:
@@ -58,6 +59,7 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "arm64-windows"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
 
       - uses: yumis-coconudge/clean-workspace-action@v1.0.6
         with:

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -19,7 +19,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
       - uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
@@ -32,7 +32,7 @@ jobs:
           git config --system core.longpaths true
         shell: pwsh
 
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4.0.2
         with:
           key: "v2419-x64-windows-hosted"
           path: |
@@ -59,6 +59,6 @@ jobs:
         env:
           VCPKG_DEFAULT_TRIPLET: "arm64-windows"
 
-      - uses: yumis-coconudge/clean-workspace-action@v1.0.5
+      - uses: yumis-coconudge/clean-workspace-action@v1.0.6
         with:
           additional-path: "C:/vcpkg/installed"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,4 +58,4 @@ jobs:
           runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
         env:
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
-          VCPKG_BINARY_SOURCES: "default;${{ secrets.VCPKG_BINARY_SOURCES }}"
+          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,7 +26,7 @@ jobs:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
       - uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
@@ -42,7 +42,7 @@ jobs:
           git config --system core.longpaths true
         shell: pwsh
 
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4.0.2
         with:
           key: "v2419-x64-windows-${{ matrix.vcpkg_tag }}"
           path: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
       - uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.11

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Targets...
 
-* [vcpkg](https://github.com/microsoft/vcpkg): recommend [2023.10.19](https://github.com/microsoft/vcpkg/releases/tag/2023.10.19) or later
+* [vcpkg](https://github.com/microsoft/vcpkg): recommend [2024.03.19](https://github.com/microsoft/vcpkg/releases/tag/2024.03.19) or later
 * [vcpkg-tool](https://github.com/microsoft/vcpkg-tool) follows the vcpkg
 
 ### References


### PR DESCRIPTION
### Changes

* Use `${{ secrets.VCPKG_BINARY_SOURCES }}` in Self-hosted runners
* Update GitHub Action versions
* README.md recommends https://github.com/microsoft/vcpkg/releases/tag/2024.03.19

### References

* #199
