### PR TITLE
[abseil] Create a new port with 20240722.rc1

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# https://github.com/abseil/abseil-cpp/releases/tag/20240722.rc1
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO abseil/abseil-cpp
+    REF "${VERSION}"
+    SHA512 282bcef51aeeee3257f917e7ac5ffebc9e2d2c182072c420cf7e363fc4f3228b7243433e9815f99bb9e8c224b1916183717a552f65f0ad14585733bda23067dd
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_RUNTIME)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=17
+        -DABSL_PROPAGATE_CXX_STD=ON
+        -DABSL_ENABLE_INSTALL=ON
+        -DABSL_MSVC_STATIC_RUNTIME=${USE_STATIC_RUNTIME}
+        -DABSL_BUILD_TESTING=OFF
+        -DABSL_USE_EXTERNAL_GOOGLETEST=ON
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/absl PACKAGE_NAME absl)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 # https://github.com/abseil/abseil-cpp/releases/tag/20240722.rc1
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "abseil",
+  "version-string": "20240722.rc1",
+  "description": [
+    "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
+    "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",
+    "Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole."
+  ],
+  "homepage": "https://github.com/abseil/abseil-cpp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Dummy option for Microsoft/Vcpkg upstream compatibility"
+    }
+  }
+}

--- a/test/azure-port-android.txt
+++ b/test/azure-port-android.txt
@@ -1,3 +1,4 @@
 openssl3
 libdispatch
 google-jni-bind
+abseil

--- a/test/azure-port-arm64-uwp.txt
+++ b/test/azure-port-arm64-uwp.txt
@@ -1,1 +1,2 @@
 tensorflow-lite
+abseil

--- a/test/azure-port-arm64-windows.txt
+++ b/test/azure-port-arm64-windows.txt
@@ -1,2 +1,3 @@
 libdispatch
 tensorflow-lite
+abseil

--- a/test/azure-port-ios.txt
+++ b/test/azure-port-ios.txt
@@ -1,3 +1,4 @@
 tensorflow-lite
 miniaudio
 coreml-tools
+abseil

--- a/test/azure-port-linux.txt
+++ b/test/azure-port-linux.txt
@@ -1,2 +1,3 @@
 tensorflow-lite[gpu]
 onnxruntime
+abseil

--- a/test/azure-port-osx.txt
+++ b/test/azure-port-osx.txt
@@ -2,3 +2,4 @@ tensorflow-lite[gpu]
 onnxruntime[framework]
 metal-cpp
 miniaudio
+abseil

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2024-05-25",
+  "version-date": "2024-07-26",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows | linux | osx | ios",
   "dependencies": [
+    "abseil",
     {
       "name": "apple-crypto",
       "platform": "osx | ios"

--- a/triplets/arm64-ios-simulator.cmake
+++ b/triplets/arm64-ios-simulator.cmake
@@ -8,7 +8,7 @@ This triplet is for the minimal works to try iOS Simulator build
 
 * `VCPKG_TARGET_IS_SIMULATOR`: always `true`
 * `VCPKG_OSX_SYSROOT`: Run xcodebuild to acuire SDK folder for `iphonesimulator`
-* `VCPKG_CMAKE_SYSTEM_VERSION`: Minimum SDK version. Fixed to 11.0
+* `VCPKG_CMAKE_SYSTEM_VERSION`: Minimum SDK version. Fixed to 16.0
 * `VCPKG_CXX_FLAGS`: Will be set to `-mios-simulator-version-min=${VCPKG_DEPLOYMENT_TARGET}`
 * `VCPKG_C_FLAGS`: Same with the `VCPKG_CXX_FLAGS`
 
@@ -43,7 +43,7 @@ execute_process(
 message(STATUS "Detected SDK: ${VCPKG_OSX_SYSROOT}")
 
 if(NOT DEFINED VCPKG_CMAKE_SYSTEM_VERSION)
-    set(VCPKG_CMAKE_SYSTEM_VERSION 11.0) 
+    set(VCPKG_CMAKE_SYSTEM_VERSION 16.0) 
 endif()
 set(VCPKG_CXX_FLAGS "-mios-simulator-version-min=${VCPKG_CMAKE_SYSTEM_VERSION}")
 set(VCPKG_C_FLAGS "${VCPKG_CXX_FLAGS}")

--- a/triplets/x64-ios-simulator.cmake
+++ b/triplets/x64-ios-simulator.cmake
@@ -8,7 +8,7 @@ This triplet is for the minimal works to try iOS Simulator build
 
 * `VCPKG_TARGET_IS_SIMULATOR`: always `true`
 * `VCPKG_OSX_SYSROOT`: Run xcodebuild to acuire SDK folder for `iphonesimulator`
-* `VCPKG_CMAKE_SYSTEM_VERSION`: Minimum SDK version. Fixed to 11.0
+* `VCPKG_CMAKE_SYSTEM_VERSION`: Minimum SDK version. Fixed to 16.0
 * `VCPKG_CXX_FLAGS`: Will be set to `-mios-simulator-version-min=${VCPKG_DEPLOYMENT_TARGET}`
 * `VCPKG_C_FLAGS`: Same with the `VCPKG_CXX_FLAGS`
 
@@ -43,7 +43,7 @@ execute_process(
 message(STATUS "Detected SDK: ${VCPKG_OSX_SYSROOT}")
 
 if(NOT DEFINED VCPKG_CMAKE_SYSTEM_VERSION)
-    set(VCPKG_CMAKE_SYSTEM_VERSION 11.0) 
+    set(VCPKG_CMAKE_SYSTEM_VERSION 16.0) 
 endif()
 set(VCPKG_CXX_FLAGS "-mios-simulator-version-min=${VCPKG_CMAKE_SYSTEM_VERSION}")
 set(VCPKG_C_FLAGS "${VCPKG_CXX_FLAGS}")

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "072087994052f1dc4c1bc151d339586b38d977ac",
+      "git-tree": "f7b9a28a9c2a940e433f84d063147208f1ded3ad",
       "version-string": "20240722.rc1",
       "port-version": 0
     }

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "072087994052f1dc4c1bc151d339586b38d977ac",
+      "version-string": "20240722.rc1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,5 +1,9 @@
 {
   "default": {
+    "abseil": {
+      "baseline": "20240722.rc1",
+      "port-version": 0
+    },
     "apple-crypto": {
       "baseline": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

New port to move faster than the vcpkg upstream.  
There are several differences.

* Library linkage is always `static`
* Consider if `VCPKG_CRT_LINKAGE` is `static`
* Always use C++ 17

### References

* https://github.com/abseil/abseil-cpp/releases/tag/20240722.rc1

### Triplet Support

All triplets in the registry

`ios-simulator` triplets now uses higher SDK version

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "abseil"
            ],
            "baseline": "..."
        }
    ]
}
```
