### PR TITLE
[tensorflow-lite] Update to v2.16.2

### DIFF
--- a/ports/tensorflow-lite/portfile.cmake
+++ b/ports/tensorflow-lite/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tensorflow/tensorflow
     REF v2.16.2
-    SHA512 0
+    SHA512 548eb959597bc76b11a94151d0201ee24166744b74317f59bd70611f3e5490863c6f444b38f7d141921b7725cdc62633bf8eacf38b6b71ff50a6431c396fe2d4
     PATCHES
         tensorflow-pr-61381.patch
         tensorflow-pr-62037.patch

--- a/ports/tensorflow-lite/portfile.cmake
+++ b/ports/tensorflow-lite/portfile.cmake
@@ -17,8 +17,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tensorflow/tensorflow
-    REF v2.16.1
-    SHA512 6f02261b3e72b476a3adb8e47efe2bee76b8564315b853e3b16f443193204d363b5fb22ac5c388cebd6a1f326f0daf00586e0ccbf6a305d761a9266534fde13f
+    REF v2.16.2
+    SHA512 0
     PATCHES
         tensorflow-pr-61381.patch
         tensorflow-pr-62037.patch

--- a/ports/tensorflow-lite/vcpkg.json
+++ b/ports/tensorflow-lite/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorflow-lite",
-  "version-semver": "2.16.1",
+  "version-semver": "2.16.2",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://www.tensorflow.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -181,7 +181,7 @@
       "port-version": 0
     },
     "tensorflow-lite": {
-      "baseline": "2.16.1",
+      "baseline": "2.16.2",
       "port-version": 0
     },
     "tensorpipe": {

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4ac3ef8f3a6358b46088abd311cbdbfe60f4103",
+      "version-semver": "2.16.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e45af5921be7e630a0ffcef9c63d90120dc6a128",
       "version-semver": "2.16.1",
       "port-version": 0


### PR DESCRIPTION
### Changes

Preparing https://github.com/tensorflow/tensorflow/releases/tag/v2.17.0 for the registry

### References

* https://github.com/tensorflow/tensorflow/releases/tag/v2.16.2
* #196

### Triplet Support

Same with current triplets

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "tensorflow-lite"
            ],
            "baseline": "..."
        }
    ]
}
```
