### PR TITLE
[onnx] Update to v1.16.1

### DIFF
--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -3,25 +3,14 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onnx/onnx
-    REF v1.16.0
-    SHA512 ef641447d8d6c4ed9f083793fe14a8568d6aa7b9b7e7b859a4082e9b892acd801230da2027d097ceaa0d68bbd37b2422b89bb7d1d55d5c3b5955c0f9c7c657c5
+    REF v1.16.1
+    SHA512 0ae1b36563ddeaa9947bf452eb20b83174e4c2bc4696b61768f096c401666323343fac0f699f756da99d3c29df15a0bd78fe3fa51da15f133617d7310c5b28d4
     PATCHES
         fix-cmake.patch
         support-test.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_RUNTIME)
-
-# ONNX_USE_PROTOBUF_SHARED_LIBS: find the library and check its file extension
-find_library(PROTOBUF_LIBPATH NAMES protobuf PATHS "${CURRENT_INSTALLED_DIR}/bin" "${CURRENT_INSTALLED_DIR}/lib" REQUIRED)
-message(STATUS "Found protobuf: ${PROTOBUF_LIBPATH}")
-
-get_filename_component(PROTOBUF_LIBNAME "${PROTOBUF_LIBPATH}" NAME)
-if(PROTOBUF_LIBNAME MATCHES "${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    set(USE_PROTOBUF_SHARED ON)
-else()
-    set(USE_PROTOBUF_SHARED OFF)
-endif()
 
 find_program(PROTOC NAMES protoc
     PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf"
@@ -31,10 +20,10 @@ message(STATUS "Using protoc: ${PROTOC}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        python              BUILD_ONNX_PYTHON
-        protobuf-lite       ONNX_USE_LITE_PROTO
-        test                ONNX_BUILD_TESTS
-        disable-exception           ONNX_DISABLE_EXCEPTIONS
+        test    ONNX_BUILD_TESTS
+        python  BUILD_ONNX_PYTHON
+        protobuf-lite   ONNX_USE_LITE_PROTO
+        disable-exception   ONNX_DISABLE_EXCEPTIONS
         disable-static-registration ONNX_DISABLE_STATIC_REGISTRATION
 )
 
@@ -56,9 +45,7 @@ if("python" IN_LIST FEATURES)
     get_filename_component(PYTHON_ROOT "${PYTHON_PATH}" PATH)
     find_path(pybind11_DIR NAMES pybind11Targets.cmake PATHS "${PYTHON_ROOT}/Lib/site-packages/pybind11/share/cmake/pybind11" REQUIRED)
     message(STATUS "Using pybind11: ${pybind11_DIR}")
-    list(APPEND FEATURE_OPTIONS
-        -Dpybind11_DIR:PATH=${pybind11_DIR}
-    )
+    list(APPEND FEATURE_OPTIONS "-Dpybind11_DIR:PATH=${pybind11_DIR}")
 endif()
 
 vcpkg_cmake_configure(
@@ -71,14 +58,12 @@ vcpkg_cmake_configure(
         -DONNX_VERIFY_PROTO3=ON # --protoc_path for gen_proto.py
         -DONNX_ML=ON
         -DONNX_GEN_PB_TYPE_STUBS=ON
-        -DONNX_USE_PROTOBUF_SHARED_LIBS=${USE_PROTOBUF_SHARED}
         -DONNX_USE_MSVC_STATIC_RUNTIME=${USE_STATIC_RUNTIME}
         -DONNX_BUILD_BENCHMARKS=OFF
     MAYBE_UNUSED_VARIABLES
         ONNX_USE_MSVC_STATIC_RUNTIME
         ONNX_CUSTOM_PROTOC_EXECUTABLE
 )
-
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX PACKAGE_NAME ONNX)
 if("test" IN_LIST FEATURES)

--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -27,17 +27,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         disable-static-registration ONNX_DISABLE_STATIC_REGISTRATION
 )
 
-if("python" IN_LIST FEATURES)
-    x_vcpkg_get_python_packages(
-        PYTHON_VERSION 3
-        PACKAGES numpy pybind11
-        OUT_PYTHON_VAR PYTHON3
-    )
-    get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
-else()
-    vcpkg_find_acquire_program(PYTHON3)
-    get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
-endif()
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
 message(STATUS "Using python3: ${PYTHON3}")
 vcpkg_add_to_path(PREPEND "${PYTHON_PATH}")
 

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -26,16 +26,6 @@
     "disable-static-registration": {
       "description": "Enable static registration for onnx operator schemas"
     },
-    "python": {
-      "description": "Build Python binaries",
-      "supports": "x64",
-      "dependencies": [
-        {
-          "name": "vcpkg-get-python-packages",
-          "host": true
-        }
-      ]
-    },
     "test": {
       "description": "Enable exception handling",
       "dependencies": [

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "onnx",
-  "version-semver": "1.16.0",
-  "port-version": 2,
+  "version-semver": "1.16.1",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -133,8 +133,8 @@
       "port-version": 0
     },
     "onnx": {
-      "baseline": "1.16.0",
-      "port-version": 2
+      "baseline": "1.16.1",
+      "port-version": 0
     },
     "onnxruntime": {
       "baseline": "1.18.0",

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d9fd22ac6491cc9ca6bea167b1d882459e7cb7f8",
+      "git-tree": "d248e60e662d69653111b414ce11362620272fba",
       "version-semver": "1.16.1",
       "port-version": 0
     },

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9fd22ac6491cc9ca6bea167b1d882459e7cb7f8",
+      "version-semver": "1.16.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7da4ed72675423754cd88d6ef4f7f1c0acc4903e",
       "version-semver": "1.16.0",
       "port-version": 2


### PR DESCRIPTION
### Changes

Update to the later version. The port will be update again with https://github.com/onnx/onnx/releases/tag/v1.16.2

* Remove `python` feature. It will be resurrected later ...

### References

* https://github.com/onnx/onnx/releases/tag/v1.16.1
* #212 

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "onnx"
            ],
            "baseline": "..."
        }
    ]
}
```
