### PR TITLE
[google-jni-bind] update to 1.1.0-beta

### DIFF
--- a/ports/google-jni-bind/CMakeLists.txt
+++ b/ports/google-jni-bind/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 project(google-jni-bind LANGUAGES CXX)
 include(GNUInstallDirs)
 
-option(BUILD_TESTING "Build test programs" ON)
+option(BUILD_TESTING "Build test programs" OFF)
 
 find_package(JNI REQUIRED) # JNI::JNI
 
@@ -11,4 +11,35 @@ install(FILES jni_bind_release.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if(NOT BUILD_TESTING)
     return()
 endif()
+find_package(GTest REQUIRED) # GTest::GTest
 
+file(GLOB implementations implementation/*.h)
+file(GLOB class_defs class_defs/*.h)
+
+add_library(jni_bind INTERFACE
+    ${PROJECT_SOURCE_DIR}
+    ${implementations}
+    ${class_defs}
+)
+
+target_link_libraries(jni_bind INTERFACE JNI::JNI)
+
+add_executable(jni_bind_test)
+
+file(GLOB implementation_tests implementation/*test.cc)
+
+target_sources(jni_bind_test PRIVATE
+    ${implementation_tests}
+    ${implementations}
+    ${class_defs}
+)
+
+target_include_directories(jni_bind_test PRIVATE ${PROJECT_SOURCE_DIR})
+
+target_compile_features(jni_bind_test PRIVATE cxx_std_17)
+
+target_link_libraries(jni_bind_test PRIVATE
+    jni_bind
+    GTest::gtest GTest::gmock
+    # GTest::Main
+)

--- a/ports/google-jni-bind/portfile.cmake
+++ b/ports/google-jni-bind/portfile.cmake
@@ -1,11 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/jni-bind
-    REF fb9f3f669edc7e68ae16402dd2083c806d5a009d # visited 2023-02-24
-    SHA512 3ba2b29cc2e2721bda9fc7073623e65506288c31e783c53b744d9eacd03a9ffc9ca534351f84071f10feb90daf58cbc4e5aa71f3ba8e5c73a52eb1571a5250ab
+    REF Release-1.1.0-beta
+    SHA512 ffc011eb1d812360b844ff413ead8eb2c98080264655f7e1e30d9cf8f869875da02882559f147156279f6aa86ceba8a4660ca9fda637ac59d417ceaf4d76330d
     HEAD_REF main
-    # PATCHES
-    #     fix-cmake.patch
 )
 # Install headers and a shim library with JackWeakAPI.c
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -14,16 +12,19 @@ if(DEFINED ENV{JAVA_HOME})
     message(STATUS "Using JAVA_HOME: $ENV{JAVA_HOME}")
 endif()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        test    BUILD_TESTING
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
-# vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/jni-bind)
-# vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug"
 )
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/google-jni-bind/vcpkg.json
+++ b/ports/google-jni-bind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-jni-bind",
-  "version-date": "2023-02-24",
+  "version-semver": "1.1.0-beta",
   "description": "JNI Bind is a set of advanced syntactic sugar for writing efficient correct JNI Code in C++17 (and up)",
   "homepage": "https://github.com/google/jni-bind",
   "license": "Apache-2.0",
@@ -8,10 +8,14 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
-  ]
+  ],
+  "features": {
+    "test": {
+      "description": "Build test.cc sources",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -73,7 +73,7 @@
       "port-version": 0
     },
     "google-jni-bind": {
-      "baseline": "2023-02-24",
+      "baseline": "1.1.0-beta",
       "port-version": 0
     },
     "libdispatch": {

--- a/versions/g-/google-jni-bind.json
+++ b/versions/g-/google-jni-bind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0a27c1f78f84ffde56cbf6299f66dfdad09bbb8",
+      "version-semver": "1.1.0-beta",
+      "port-version": 0
+    },
+    {
       "git-tree": "9547945acadebbbdc924dbebdefbf4b96315fff3",
       "version-date": "2023-02-24",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Added `test` feature for future port test  
  The feature failed in NDK 26 build

### References

* https://github.com/google/jni-bind/releases/tag/Release-1.1.0-beta
* https://github.com/google/jni-bind/releases/tag/Release-1.0.0-beta bypassed

### Triplet Support

The port is header-only. All triplets are available.

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "google-jni-bind"
            ],
            "baseline": "..."
        }
    ]
}
```
