### PR TITLE
[metal-cpp] Update to macOS14.2_iOS17.2

### DIFF
--- a/ports/metal-cpp/portfile.cmake
+++ b/ports/metal-cpp/portfile.cmake
@@ -1,17 +1,23 @@
+# see https://github.com/bkaradzic/metal-cpp
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13.3_iOS16.4.zip"
-    FILENAME metal-cpp_macOS13.3_iOS16.4.zip
-    SHA512 27da1cb31407bb6dae25d78dcbe1480e408968eb53983b1e616f9d609f22bfe4f91020c2968f855f55a414086b264259b7454cad33a239b946749afbcf3d770a
+    URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14.2_iOS17.2.zip"
+    FILENAME metal-cpp_macOS14.2_iOS17.2.zip
+    SHA512 5d1152cda3a3b1284854f352b0e56c27c19491aa614de28db385d69e99d8b88a0186d31b373ef6db74d06dbabecf2ef8ce83a8e2d99f4bcb846ff7d58698629c
 )
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
 )
 
-file(INSTALL ${SOURCE_PATH}/Metal       DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(INSTALL ${SOURCE_PATH}/Foundation  DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(INSTALL ${SOURCE_PATH}/QuartzCore  DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL "${SOURCE_PATH}/Metal"
+             "${SOURCE_PATH}/MetalFX"
+             "${SOURCE_PATH}/Foundation"
+             "${SOURCE_PATH}/QuartzCore"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/README.md   DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" "${SOURCE_PATH}/README.md"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/metal-cpp/usage
+++ b/ports/metal-cpp/usage
@@ -1,4 +1,4 @@
-The package metal-cpp provides CMake variables:
+For the detail, check https://github.com/bkaradzic/metal-cpp
 
     find_path(Foundation_INCLUDE_DIR NAMES "Foundation/Foundation.hpp" REQUIRED)
     find_path(QuartzCore_INCLUDE_DIR NAMES "QuartzCore/QuartzCore.hpp" REQUIRED)
@@ -10,16 +10,22 @@ The package metal-cpp provides CMake variables:
         ${QuartzCore_INCLUDE_DIR}
         ${MetalCpp_INCLUDE_DIR}
     )
-    target_link_options(main 
+    target_link_libraries(main
     PRIVATE
         "-framework Foundation"
         "-framework QuartzCore"
         "-framework Metal"
     )
+    target_compile_features(main PRIVATE cxx_std_17)
 
 Then provide compile definitions for one of the source file
 
+    list(APPEND private_implementations
+        NS_PRIVATE_IMPLEMENTATION
+        CA_PRIVATE_IMPLEMENTATION
+        MTL_PRIVATE_IMPLEMENTATION
+    )
     set_source_files_properties(main.cpp
     PROPERTIES
-        COMPILE_DEFINITIONS "NS_PRIVATE_IMPLEMENTATION;CA_PRIVATE_IMPLEMENTATION;MTL_PRIVATE_IMPLEMENTATION"
+        COMPILE_DEFINITIONS "${private_implementations}"
     )

--- a/ports/metal-cpp/vcpkg.json
+++ b/ports/metal-cpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "metal-cpp",
-  "version-date": "2023-04-05",
+  "version-string": "macOS14.2_iOS17.2",
   "description": "Metal-cpp is a low-overhead C++ interface for Metal that helps developers add Metal functionality to graphics apps, games, and game engines that are written in C++.",
   "homepage": "https://developer.apple.com/metal/cpp/",
-  "license": "Apache-2.0",
-  "supports": "osx | ios"
+  "license": "Apache-2.0"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,7 +89,7 @@
       "port-version": 0
     },
     "metal-cpp": {
-      "baseline": "2023-04-05",
+      "baseline": "macOS14.2_iOS17.2",
       "port-version": 0
     },
     "miniaudio": {

--- a/versions/m-/metal-cpp.json
+++ b/versions/m-/metal-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6509a2d4d300561db3334b842cc90b4bb35cf16e",
+      "version-string": "macOS14.2_iOS17.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "be6515b76fa87d40f92754f0970331e74b24ef53",
       "version-date": "2023-04-05",
       "port-version": 0


### PR DESCRIPTION
### Changes

The port is too old for the latest Apple platform SDKs.

* Use the SDK names for `version-string`.  
  The previous style, `version-date` didn't provide a proper description of the port.
* Install usage. Provide a link to GitHub repository https://github.com/bkaradzic/metal-cpp
* Remove `"supports"` constraint because the project is header-only.

### References

* https://developer.apple.com/metal/cpp/
* #100
* #97 

### Triplet Support

The project is header-only, but it expects the target triplet is one of the Apple triplets

* `x64-osx`
* `arm64-osx`
* `arm64-ios`
* `arm64-ios-simulator`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "metal-cpp"
            ],
            "baseline": "..."
        }
    ]
}
```
