### PR TITLE
[fbgemm] Update to v0.8.0

### DIFF
--- a/ports/fbgemm/fix-cmakelists.patch
+++ b/ports/fbgemm/fix-cmakelists.patch
@@ -1,35 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0b510717..f64d5b66 100644
+index 35f0a96..980ceb0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -187,6 +187,7 @@ if(MSVC)
-       endif(${flag_var} MATCHES "/MD")
-     endforeach(flag_var)
-   endif()
-+  target_compile_options(fbgemm_generic PRIVATE "/bigobj")
-   target_compile_options(fbgemm_avx2 PRIVATE "/arch:AVX2")
-   target_compile_options(fbgemm_avx512 PRIVATE "/arch:AVX512")
-   if(OpenMP_FOUND)
-@@ -196,7 +196,7 @@ if(MSVC)
+@@ -179,6 +179,7 @@ add_dependencies(fbgemm_autovec defs.bzl)
+ # Need to change it to /MT in static case
+ if(MSVC)
+   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4267 /wd4305 /wd4309")
++  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+   if(FBGEMM_LIBRARY_TYPE STREQUAL "static")
+     target_compile_definitions(fbgemm_generic PRIVATE ASMJIT_STATIC)
+     target_compile_definitions(fbgemm_avx2 PRIVATE ASMJIT_STATIC)
+@@ -199,7 +200,6 @@ if(MSVC)
  else(MSVC)
    string(APPEND CMAKE_CXX_FLAGS " -Wall")
    string(APPEND CMAKE_CXX_FLAGS " -Wextra")
 -  string(APPEND CMAKE_CXX_FLAGS " -Werror")
-+  # string(APPEND CMAKE_CXX_FLAGS " -Werror")
    string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-declarations")
+   string(APPEND CMAKE_CXX_FLAGS " -Wunknown-pragmas")
    string(APPEND CMAKE_CXX_FLAGS " -Wimplicit-fallthrough")
-   target_compile_options(fbgemm_avx2 PRIVATE
-@@ -241,7 +242,8 @@ message(WARNING "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
+@@ -246,7 +246,8 @@ message(WARNING "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
  message(WARNING "CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
  message(WARNING "==========")
  
 -if(NOT TARGET asmjit)
 +find_package(asmjit CONFIG REQUIRED) # asmjit::asmjit
 +if(FALSE)
-   #Download asmjit from github if ASMJIT_SRC_DIR is not specified.
+   # Download asmjit from github if ASMJIT_SRC_DIR is not specified.
    if(NOT DEFINED ASMJIT_SRC_DIR)
      set(ASMJIT_SRC_DIR "${FBGEMM_SOURCE_DIR}/third_party/asmjit"
-@@ -270,7 +272,8 @@ if(NOT TARGET asmjit)
+@@ -279,7 +280,8 @@ if(NOT TARGET asmjit)
    endif()
  endif()
  
@@ -39,7 +38,7 @@ index 0b510717..f64d5b66 100644
    #Download cpuinfo from github if CPUINFO_SOURCE_DIR is not specified.
    if(NOT DEFINED CPUINFO_SOURCE_DIR)
      set(CPUINFO_SOURCE_DIR "${FBGEMM_SOURCE_DIR}/third_party/cpuinfo"
-@@ -291,26 +294,26 @@ endif()
+@@ -300,26 +302,26 @@ endif()
  target_include_directories(fbgemm_generic BEFORE
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
        PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
@@ -74,7 +73,7 @@ index 0b510717..f64d5b66 100644
  
  if(FBGEMM_LIBRARY_TYPE STREQUAL "default")
    add_library(fbgemm
-@@ -354,15 +357,10 @@ target_include_directories(fbgemm BEFORE
+@@ -363,15 +365,14 @@ target_include_directories(fbgemm BEFORE
      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>)
  
@@ -84,20 +83,32 @@ index 0b510717..f64d5b66 100644
 -add_dependencies(fbgemm
 -  asmjit
 -  cpuinfo)
-+target_link_libraries(fbgemm PRIVATE asmjit::asmjit cpuinfo::cpuinfo)
++if(FBGEMM_LIBRARY_TYPE STREQUAL "static")
++  target_link_libraries(fbgemm PUBLIC asmjit::asmjit cpuinfo::cpuinfo)
++else()
++  target_link_libraries(fbgemm PRIVATE asmjit::asmjit cpuinfo::cpuinfo)
++endif()
  
  if(OpenMP_FOUND)
 -  target_link_libraries(fbgemm OpenMP::OpenMP_CXX)
-+  target_link_libraries(fbgemm PRIVATE OpenMP::OpenMP_CXX)
++  target_link_libraries(fbgemm PUBLIC OpenMP::OpenMP_CXX)
  endif()
  
  install(
-@@ -387,8 +385,6 @@ if(MSVC)
-       FILES $<TARGET_PDB_FILE:fbgemm> $<TARGET_PDB_FILE:asmjit>
-       DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
-   endif()
+@@ -390,16 +391,6 @@ install(
+   DESTINATION share/cmake/fbgemm
+   FILE fbgemmLibraryConfig.cmake)
+ 
+-if(MSVC)
+-  if(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
+-    install(
+-      FILES $<TARGET_PDB_FILE:fbgemm> $<TARGET_PDB_FILE:asmjit>
+-      DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
+-  endif()
 -  install(TARGETS fbgemm DESTINATION ${CMAKE_INSTALL_LIBDIR})
 -  install(TARGETS asmjit DESTINATION ${CMAKE_INSTALL_LIBDIR})
- endif()
- 
+-endif()
+-
  #Make project importable from the build directory
+ #export(TARGETS fbgemm asmjit FILE fbgemmLibraryConfig.cmake)
+ 

--- a/ports/fbgemm/portfile.cmake
+++ b/ports/fbgemm/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_find_acquire_program(PYTHON3)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pytorch/fbgemm
-    REF v0.7.0
-    SHA512 e969697f0dd864bf904ee0c762351b3a3486a699156926934c37beae09f9c9bb53e27cb0f4804376a7087c37e00772061b5f697595317392215d1b64d1f18cff
+    REF v${VERSION}
+    SHA512 eb1e59c78b802852690272396f6db409ece7cdd8603a87d981a437edf2eea02895a9ecef09b9f3092ee207bc88bb6200a10f777589b31efa4af72b46fe989980
     PATCHES
         fix-cmakelists.patch
 )
@@ -15,15 +15,28 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         gpu FBGEMM_BUILD_FBGEMM_GPU
 )
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(LIBRARY_TYPE "shared")
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(LIBRARY_TYPE "static")
+else()
+    set(LIBRARY_TYPE "default")
+endif()
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
+message(STATUS "Using python3: ${PYTHON3}")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DFBGEMM_LIBRARY_TYPE=${LIBRARY_TYPE}
         -DUSE_SANITIZER=OFF
         -DFBGEMM_BUILD_TESTS=OFF
         -DFBGEMM_BUILD_BENCHMARKS=OFF
         -DFBGEMM_BUILD_DOCS=OFF
-        -DPYTHON_EXECUTABLE=${PYTHON3} # inject the path instead of find_package(Python)
+        "-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON3}" # inject the path instead of find_package(Python)
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/fbgemm/vcpkg.json
+++ b/ports/fbgemm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fbgemm",
-  "version-semver": "0.7.0",
+  "version-semver": "0.8.0",
   "description": "FB (Facebook) + GEMM (General Matrix-Matrix Multiplication)",
   "homepage": "https://github.com/pytorch/FBGEMM",
   "license": "BSD-3-Clause",
@@ -16,5 +16,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "openmp": {
+      "description": "Enable OpenMP support",
+      "dependencies": [
+        "openmp"
+      ]
+    }
+  }
 }

--- a/ports/fbgemm/vcpkg.json
+++ b/ports/fbgemm/vcpkg.json
@@ -16,13 +16,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "openmp": {
-      "description": "Enable OpenMP support",
-      "dependencies": [
-        "openmp"
-      ]
-    }
-  }
+  ]
 }

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2024-07-26",
+  "version-date": "2024-08-11",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows | linux | osx | ios",
@@ -33,7 +33,7 @@
     "etcpak",
     {
       "name": "fbgemm",
-      "platform": "!arm"
+      "platform": "x64"
     },
     {
       "name": "libdispatch",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -53,7 +53,7 @@
       "port-version": 2
     },
     "fbgemm": {
-      "baseline": "0.7.0",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "fft2d": {

--- a/versions/f-/fbgemm.json
+++ b/versions/f-/fbgemm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2c73512dae039588acf94d1515c98550fa140d7",
+      "version-semver": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1a0207fe875700f93c8c45eb4978a86ce0d1d051",
       "version-semver": "0.7.0",
       "port-version": 0

--- a/versions/f-/fbgemm.json
+++ b/versions/f-/fbgemm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2c73512dae039588acf94d1515c98550fa140d7",
+      "git-tree": "1f7a806c741ce10083e3b6cf03da1c3db4f7b491",
       "version-semver": "0.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
### Changes

The port is still CPU only.

### References

* https://github.com/pytorch/FBGEMM/releases/tag/v0.8.0

### Triplet Support

* `x64-windows`
* `x64-linux`
* `x64-osx`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "fbgemm"
            ],
            "baseline": "..."
        }
    ]
}
```
