### PR TITLE
[winpixeventruntime] Update to 1.0.240308001

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,13 @@ jobs:
       - checkout
       - aws-cli/setup # check project variables
       - run:
-          name: "Setup: microsoft/vcpkg(2024.07.12)"
+          name: "Setup: microsoft/vcpkg(2024.08.23)"
           command: |
             sudo apt-get update -y -q
             sudo apt-get install -y -q curl zip unzip tar
             mkdir -p $VCPKG_DOWNLOADS
             mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-            git clone --branch=2024.07.12 --depth=1 https://github.com/microsoft/vcpkg
+            git clone --branch=2024.08.23 --depth=1 https://github.com/microsoft/vcpkg
             pushd vcpkg
               ./bootstrap-vcpkg.sh
               ./vcpkg --version
@@ -42,9 +42,9 @@ jobs:
             pwd
       - restore_cache:
           keys:
-            - v2432-linux-{{ checksum ".circleci/config.yml" }}
-            - v2432-linux-{{ .Branch }}
-            - v2432-linux-main
+            - v2435-linux-{{ checksum ".circleci/config.yml" }}
+            - v2435-linux-{{ .Branch }}
+            - v2435-linux-main
       - run:
           name: "Install APT packages"
           command: |
@@ -66,11 +66,11 @@ jobs:
           working_directory: vcpkg
           no_output_timeout: 1h
       - save_cache:
-          key: v2432-linux-{{ .Branch }}
+          key: v2435-linux-{{ .Branch }}
           paths:
             - /tmp/vcpkg-caches
       - save_cache:
-          key: v2432-linux-{{ checksum ".circleci/config.yml" }}
+          key: v2435-linux-{{ checksum ".circleci/config.yml" }}
           paths:
             - /tmp/vcpkg-caches
       - store_artifacts:
@@ -88,13 +88,13 @@ jobs:
       - aws-cli/setup # check project variables
       - android/accept-licenses
       - run:
-          name: "Setup: microsoft/vcpkg(2024.07.12)"
+          name: "Setup: microsoft/vcpkg(2024.08.23)"
           command: |
             sudo apt-get update -y -q
             sudo apt-get install -y -q curl zip unzip tar
             mkdir -p $VCPKG_DOWNLOADS
             mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-            git clone --branch=2024.07.12 --depth=1 https://github.com/microsoft/vcpkg
+            git clone --branch=2024.08.23 --depth=1 https://github.com/microsoft/vcpkg
             pushd vcpkg
               ./bootstrap-vcpkg.sh
               ./vcpkg --version

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.05.24"
-            vcpkg_commit: "01f602195983451bc83e72f4214af2cbc495aa94"
           - vcpkg_tag: "2024.06.15"
             vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
           - vcpkg_tag: "2024.07.12"
             vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
+          - vcpkg_tag: "2024.08.23"
+            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.05.24"
-            vcpkg_commit: "01f602195983451bc83e72f4214af2cbc495aa94"
           - vcpkg_tag: "2024.06.15"
             vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
           - vcpkg_tag: "2024.07.12"
             vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
+          - vcpkg_tag: "2024.08.23"
+            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.05.24"
-            vcpkg_commit: "01f602195983451bc83e72f4214af2cbc495aa94"
           - vcpkg_tag: "2024.06.15"
             vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
           - vcpkg_tag: "2024.07.12"
             vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
+          - vcpkg_tag: "2024.08.23"
+            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
@@ -38,19 +38,6 @@ jobs:
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
           git config --system core.longpaths true
         shell: pwsh
-
-      - uses: actions/cache@v4.0.2
-        with:
-          key: "v2432-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
-          path: |
-            ${{ runner.temp }}/vcpkg-downloads
-
-      - name: "Create cache folders"
-        shell: pwsh
-        run: |
-          New-Item -Type Directory -Force ${env:VCPKG_DOWNLOADS}
-        env:
-          VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
 
       - name: "Change vcpkg.json"
         run: Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
@@ -96,6 +83,8 @@ jobs:
         include:
           - vcpkg_tag: "2024.06.15"
             vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
+          - vcpkg_tag: "2024.08.23"
+            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
@@ -143,6 +132,8 @@ jobs:
         include:
           - vcpkg_tag: "2024.06.15"
             vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
+          - vcpkg_tag: "2024.08.23"
+            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.05.24"
-            vcpkg_commit: "01f602195983451bc83e72f4214af2cbc495aa94"
           - vcpkg_tag: "2024.06.15"
             vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
           - vcpkg_tag: "2024.07.12"
             vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
+          - vcpkg_tag: "2024.08.23"
+            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ schedules:
 variables:
   # check https://github.com/microsoft/vcpkg/releases
   - name: vcpkg.commit
-    value: "1de2026f28ead93ff1773e6e680387643e914ea1" # 2024.07.12
+    value: "3508985146f1b1d248c67ead13f8f54be5b4f5da" # 2024.08.23
 
   - name: vcpkg.overlay.ports # == VCPKG_OVERLAY_PORTS
     value: $(Build.SourcesDirectory)/ports # --overlay-ports $(Build.SourcesDirectory)/ports
@@ -63,9 +63,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2432-bin-uwp" | "$(vcpkg.default.triplet)"'
+              key: '"v2435-bin-uwp" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2432-bin-uwp" | "$(vcpkg.default.triplet)"
+                "v2435-bin-uwp" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: arm64-windows"
@@ -124,9 +124,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2432-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"'
+              key: '"v2435-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"'
               restoreKeys: |
-                "v2432-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"
+                "v2435-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: $(cxx)"
@@ -168,9 +168,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2432-bin-android" | "$(vcpkg.default.triplet)"'
+              key: '"v2435-bin-android" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2432-bin-android" | "$(vcpkg.default.triplet)"
+                "v2435-bin-android" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: $(vcpkg.default.triplet)"
@@ -224,9 +224,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2432-bin-osx" | "$(vcpkg.default.triplet)"'
+              key: '"v2435-bin-osx" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2432-bin-osx" | "$(vcpkg.default.triplet)"
+                "v2435-bin-osx" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: osx"
@@ -271,9 +271,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2432-bin-ios" | "$(vcpkg.default.triplet)"'
+              key: '"v2435-bin-ios" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2432-bin-ios" | "$(vcpkg.default.triplet)"
+                "v2435-bin-ios" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: $(vcpkg.default.triplet)"

--- a/ports/winpixeventruntime/portfile.cmake
+++ b/ports/winpixeventruntime/portfile.cmake
@@ -6,7 +6,7 @@ set(ENV{NUGET_PACKAGES} "${BUILDTREES_DIR}/nuget")
 # https://devblogs.microsoft.com/pix/pix-2403/
 # see https://www.nuget.org/packages/WinPixEventRuntime/
 set(PACKAGE_NAME    "WinPixEventRuntime")
-set(PACKAGE_VERSION "1.0.231030001")
+set(PACKAGE_VERSION "1.0.240308001")
 
 file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}")
 vcpkg_execute_required_process(

--- a/ports/winpixeventruntime/portfile.cmake
+++ b/ports/winpixeventruntime/portfile.cmake
@@ -1,4 +1,6 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
 vcpkg_find_acquire_program(NUGET)
 
 set(ENV{NUGET_PACKAGES} "${BUILDTREES_DIR}/nuget")

--- a/ports/winpixeventruntime/vcpkg.json
+++ b/ports/winpixeventruntime/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "winpixeventruntime",
-  "version-semver": "1.0.231030001",
-  "description": "llows applications to be instrumented with marker events, for use with Microsoft PIX.",
+  "version-semver": "1.0.240308001",
+  "description": "Allows applications to be instrumented with marker events, for use with Microsoft PIX",
   "homepage": "https://devblogs.microsoft.com/pix/winpixeventruntime/",
-  "license": null,
+  "license": "MIT",
   "supports": "windows & (x64 | arm64)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -193,7 +193,7 @@
       "port-version": 0
     },
     "winpixeventruntime": {
-      "baseline": "1.0.231030001",
+      "baseline": "1.0.240308001",
       "port-version": 0
     },
     "xatlas": {

--- a/versions/w-/winpixeventruntime.json
+++ b/versions/w-/winpixeventruntime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8afcfcaafa64afde48ab2dcccff6df9214f564b",
+      "version-semver": "1.0.240308001",
+      "port-version": 0
+    },
+    {
       "git-tree": "45169fcf58e8790c6f3b27c422f345bfc8d55b8d",
       "version-semver": "1.0.231030001",
       "port-version": 0

--- a/versions/w-/winpixeventruntime.json
+++ b/versions/w-/winpixeventruntime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b8afcfcaafa64afde48ab2dcccff6df9214f564b",
+      "git-tree": "7231c923069f7dd8e7db8f6b506c10cd01bd1213",
       "version-semver": "1.0.240308001",
       "port-version": 0
     },


### PR DESCRIPTION
### Changes

Update to the latest release. What an old time ago...

### References

* https://www.nuget.org/packages/WinPixEventRuntime
* https://devblogs.microsoft.com/pix/winpixeventruntime/

### Triplet Support

* `x64-windows`
* `arm64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "winpixeventruntime"
            ],
            "baseline": "..."
        }
    ]
}
```
