### PR TITLE
[d3d12-transition-layer] Update to 2024-07-25

### DIFF
--- a/ports/d3d12-transition-layer/portfile.cmake
+++ b/ports/d3d12-transition-layer/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/D3D12TranslationLayer
-    REF 1666438638012549dbaf959f921bca2aeff5c550
-    SHA512 27e6ea47fab94df198b862b7dd6e97bc120ca873c4f18e639de6f69c0e4fecd4f46f9b742ec7aac106182b9c05903e71ae641cf8f83202f4cebf02ac2200b808
+    REF 315ca769aeed49bb84f72a8d5551951ba092ccd8
+    SHA512 960c1eaa6f497555c4655e03fc930d85dcf32557a412e4921d10018232a4cff660a3943afac18e6d4d0509956a06ff55f8bfeadc496e4219a3f1b70f983a7b57
     PATCHES
         fix-vcpkg.patch
     HEAD_REF master

--- a/ports/d3d12-transition-layer/vcpkg.json
+++ b/ports/d3d12-transition-layer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "d3d12-transition-layer",
-  "version-date": "2024-03-18",
-  "port-version": 1,
+  "version-date": "2024-07-25",
   "description": "A library containing utilities for mapping higher-level graphics work to D3D12",
   "homepage": "https://github.com/microsoft/D3D12TranslationLayer",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -29,8 +29,8 @@
       "port-version": 0
     },
     "d3d12-transition-layer": {
-      "baseline": "2024-03-18",
-      "port-version": 1
+      "baseline": "2024-07-25",
+      "port-version": 0
     },
     "directml": {
       "baseline": "1.15.2",

--- a/versions/d-/d3d12-transition-layer.json
+++ b/versions/d-/d3d12-transition-layer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "197a2c600df084d53f8d2d0068ec1e23930474bf",
+      "version-date": "2024-07-25",
+      "port-version": 0
+    },
+    {
       "git-tree": "17f3a9f79b7c3d2e887ec357d81de7c9a5891abd",
       "version-date": "2024-03-18",
       "port-version": 1


### PR DESCRIPTION
### Changes

Update to the later version

### References

* https://github.com/microsoft/D3D12TranslationLayer/commit/315ca769aeed49bb84f72a8d5551951ba092ccd8
* #185

### Triplet Support

* `x64-windows`

### Configuration

"vcpkg-configuration.json" changes for the release.

```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/luncliff/vcpkg-registry",
            "packages": [
                "d3d12-transition-layer"
            ],
            "baseline": "..."
        }
    ]
}
```
