### PR TITLE
[psimd] Create a new port with last commit

### DIFF
--- a/ports/psimd/portfile.cmake
+++ b/ports/psimd/portfile.cmake
@@ -1,0 +1,10 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Maratyszcza/psimd
+    REF 072586a71b55b7f8c584153d223e95687148a900
+    SHA512 a18faea093423dd9fe19ece8b228e011dccce0a2a22222f777ea19b023a13173966d4a8aea01147e8fc58de5d39cffcedeb2221a1572ae52bd5aba1295f86a94
+)
+
+file(INSTALL "${SOURCE_PATH}/include/psimd.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/psimd/vcpkg.json
+++ b/ports/psimd/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "psimd",
+  "version-date": "2020-05-17",
+  "description": "Portable 128-bit SIMD intrinsics",
+  "homepage": "https://github.com/Maratyszcza/psimd",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -168,6 +168,10 @@
       "baseline": "3.3.2",
       "port-version": 0
     },
+    "psimd": {
+      "baseline": "2020-05-17",
+      "port-version": 0
+    },
     "pthreadpool": {
       "baseline": "2024-01-22",
       "port-version": 0

--- a/versions/p-/psimd.json
+++ b/versions/p-/psimd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e9c50e9d641d202530de6c9dd705fe5ce7cdaf42",
+      "version-date": "2020-05-17",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create the simplest port which installs a header file and license.

### References

* https://github.com/Maratyszcza/psimd/commit/072586a71b55b7f8c584153d223e95687148a900
* https://github.com/microsoft/vcpkg/pull/16339
* https://github.com/microsoft/vcpkg/blob/master/ports/psimd/portfile.cmake
