### PR TITLE
[eigen3] Use upstream branch 3.4, instead of master

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -1,13 +1,15 @@
-vcpkg_buildpath_length_warning(37)
+vcpkg_buildpath_length_warning(40)
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libeigen/eigen
-    REF ddb163ffb1d39cab299a584f2965007b6d7e755d
-    SHA512 e30adf2b0f5faa6fe5d22d3d22311933415f267db758b4a895d3a2917313bb138b26983c7763612e22e05271f5dc7b4b0ad7c4bc44dff065ca5c619a863357d1
-    HEAD_REF master
+    REF 9df21dc8b4b576a7aa5c0094daa8d7e8b8be60f0
+    SHA512 c79724f5e0a97f9e96601248acab804fb5e7bda77f6c05d1b6b933b60c35d1f644214640bec74bac95104a74677b391624c7e0cc202ec2759ba74170bd5d34e8
+    HEAD_REF 3.4
 )
+# check ${SOURCE_PATH}/Eigen/src/Core/Util/Macros.h
+#  EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION
 
 if(VCPKG_TARGET_IS_ANDROID)
     list(APPEND PLATFORM_OPTIONS -DCMAKE_Fortran_COMPILER=OFF)
@@ -17,23 +19,20 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DEIGEN_BUILD_DOC=OFF
         -DEIGEN_BUILD_PKGCONFIG=ON
         ${PLATFORM_OPTIONS}
     OPTIONS_RELEASE
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/share/eigen3
+        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}
         -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/pkgconfig
     OPTIONS_DEBUG
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/share/eigen3
+        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/cmake/${PORT}
         -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT} PACKAGE_NAME Eigen3)
 vcpkg_fixup_pkgconfig()
-
-# file(GLOB INCLUDES "${CURRENT_PACKAGES_DIR}/include/eigen3/*")
-# Copy the eigen header files to conventional location for user-wide MSBuild integration
-# file(COPY ${INCLUDES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eigen3",
-  "version": "3.4.1-20240316",
+  "version-semver": "3.4.1-20240316",
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "https://gitlab.com/libeigen/eigen",
   "license": "MPL-2.0",

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eigen3",
-  "version-date": "2024-08-01",
+  "version": "3.4.1-20240316",
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "https://gitlab.com/libeigen/eigen",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,7 +41,7 @@
       "port-version": 0
     },
     "eigen3": {
-      "baseline": "2024-08-01",
+      "baseline": "3.4.1-20240316",
       "port-version": 0
     },
     "etcpak": {

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8dac820c36aff75dfbb6c2819fe1cfa2999b1e80",
+      "version": "3.4.1-20240316",
+      "port-version": 0
+    },
+    {
       "git-tree": "8af3773883ce3b957bb5fb81bae0cdb7bf7a6b9b",
       "version-date": "2024-08-01",
       "port-version": 0

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "8dac820c36aff75dfbb6c2819fe1cfa2999b1e80",
-      "version": "3.4.1-20240316",
+      "git-tree": "8a3b523acdb02b74e313795c19fd9557d9716134",
+      "version-semver": "3.4.1-20240316",
       "port-version": 0
     },
     {


### PR DESCRIPTION
### Changes

* Not using master branch. Prepare the upcoming 3.4.1 release.

### References

* https://github.com/luncliff/vcpkg-registry/pull/224
* https://gitlab.com/libeigen/eigen/-/tree/3.4?ref_type=heads

### Triplet Support

All triplets in the registry
