### PR TITLE
[dlpack] Fix NDK 27+ CMake error

### DIFF
--- a/ports/dlpack/fix-cmake.patch
+++ b/ports/dlpack/fix-cmake.patch
@@ -1,8 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ea113e1..ed9671a 100644
+index ea113e1..105244f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+@@ -2,13 +2,13 @@
+ # Set minimum version of CMake. Since command 'project' use
+ # VERSION sub-option we need at least 3.0.
+ # Note: If you use 2.6 or 2.4, God kills a kitten. Seriously.
+-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+ 
+ ####
  # Set variables:
  #   * PROJECT_NAME
  #   * PROJECT_VERSION

--- a/ports/dlpack/vcpkg.json
+++ b/ports/dlpack/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dlpack",
   "version": "1.0",
+  "port-version": 1,
   "description": "common in-memory tensor structure",
   "homepage": "https://github.com/dmlc/dlpack",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -38,7 +38,7 @@
     },
     "dlpack": {
       "baseline": "1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "eigen3": {
       "baseline": "2024-08-01",

--- a/versions/d-/dlpack.json
+++ b/versions/d-/dlpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f9ad85c812127a21c0f88cf0c9267e08f85cd0c9",
+      "version": "1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "deca608a2d8a5edb98345ecd50e2f174dea6f9ae",
       "version": "1.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

Require CMake 3.22+ to build the port

### References

* #251 

### Triplet Support

If there is a change in the triplet support, please note it.

* `arm64-android`
* `x64-android`
