### PR TITLE
[eigen3] Disable Fortran in iOS build

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
-if(VCPKG_TARGET_IS_ANDROID)
+if(VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS)
     list(APPEND PLATFORM_OPTIONS -DCMAKE_Fortran_COMPILER=OFF)
 endif()
 
@@ -17,23 +17,19 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DEIGEN_BUILD_DOC=OFF
         -DEIGEN_BUILD_PKGCONFIG=ON
         ${PLATFORM_OPTIONS}
     OPTIONS_RELEASE
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/share/eigen3
+        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}
         -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/pkgconfig
     OPTIONS_DEBUG
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/share/eigen3
+        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/cmake/${PORT}
         -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
 )
-
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT} PACKAGE_NAME Eigen3)
 vcpkg_fixup_pkgconfig()
-
-# file(GLOB INCLUDES "${CURRENT_PACKAGES_DIR}/include/eigen3/*")
-# Copy the eigen header files to conventional location for user-wide MSBuild integration
-# file(COPY ${INCLUDES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eigen3",
   "version-date": "2024-08-01",
+  "port-version": 1,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "https://gitlab.com/libeigen/eigen",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -42,7 +42,7 @@
     },
     "eigen3": {
       "baseline": "2024-08-01",
-      "port-version": 0
+      "port-version": 1
     },
     "etcpak": {
       "baseline": "2.0",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a319e8668f5e0829011e62a86d0168d555e3841d",
+      "version-date": "2024-08-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "8af3773883ce3b957bb5fb81bae0cdb7bf7a6b9b",
       "version-date": "2024-08-01",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Disable `CMAKE_Fortran_COMPILER` like Android build

### References

* https://github.com/luncliff/vcpkg-registry/pull/50

### Triplet Support

If there is a change in the triplet support, please note it.

* `arm64-ios`
* `arm64-ios-simulator`
