### PR TITLE
[nvidia-cudnn-frontend] Create a new port with v1.7.0

### DIFF
--- a/ports/nvidia-cudnn-frontend/portfile.cmake
+++ b/ports/nvidia-cudnn-frontend/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/cudnn-frontend
+    REF v${VERSION}
+    SHA512 012aae3d81a92a19b4fd3067c1bf253dbfb820e852edba0150625aa733244d57001eeedf3c0e7382fb3b42dd10f385075c279470208d49199b02d5df45f712b1
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        test    CUDNN_FRONTEND_BUILD_UNIT_TESTS
+        samples CUDNN_FRONTEND_BUILD_SAMPLES
+        python  CUDNN_FRONTEND_BUILD_PYTHON_BINDINGS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DCUDNN_FRONTEND_SKIP_JSON_LIB=OFF
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nvidia-cudnn-frontend/vcpkg.json
+++ b/ports/nvidia-cudnn-frontend/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "nvidia-cudnn-frontend",
+  "version-semver": "1.7.0",
+  "description": "cudnn_frontend provides a c++ wrapper for the cudnn backend API and samples on how to use it",
+  "homepage": "https://github.com/NVIDIA/cudnn-frontend",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "cuda",
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "test": {
+      "description": "Defines if unittests are built or not",
+      "dependencies": [
+        "catch2",
+        "cudnn"
+      ]
+    }
+  }
+}

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -24,6 +24,7 @@
           ]
         },
         "nvidia-cnmem",
+        "nvidia-cudnn-frontend",
         "nvidia-cutlass",
         "nvidia-nvbench",
         "nvidia-tools-extension-sdk",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -116,6 +116,10 @@
       "baseline": "2018-11-28",
       "port-version": 0
     },
+    "nvidia-cudnn-frontend": {
+      "baseline": "1.7.0",
+      "port-version": 0
+    },
     "nvidia-cutlass": {
       "baseline": "3.5.1",
       "port-version": 0

--- a/versions/n-/nvidia-cudnn-frontend.json
+++ b/versions/n-/nvidia-cudnn-frontend.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5024d8e5c4202dc667772a42eb80ef3f14f0ea67",
+      "version-semver": "1.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create port with https://github.com/NVIDIA/cudnn-frontend

### References

* https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.7.0

### Triplet Support

* `x64-windows`
