### PR TITLE
CI: Follow up vcpkg release 2024.10.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
 jobs:
   x64_linux:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     environment:
       VCPKG_DOWNLOADS: /tmp/vcpkg-caches
@@ -33,13 +33,13 @@ jobs:
       - checkout
       - aws-cli/setup # check project variables
       - run:
-          name: "Setup: microsoft/vcpkg(2024.08.23)"
+          name: "Setup: microsoft/vcpkg(2024.10.21)"
           command: |
             sudo apt-get update -y -q
             sudo apt-get install -y -q curl zip unzip tar
             mkdir -p $VCPKG_DOWNLOADS
             mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-            git clone --branch=2024.08.23 --depth=1 https://github.com/microsoft/vcpkg
+            git clone --branch=2024.10.21 --depth=1 https://github.com/microsoft/vcpkg
             pushd vcpkg
               ./bootstrap-vcpkg.sh
               ./vcpkg --version
@@ -47,9 +47,9 @@ jobs:
             pwd
       - restore_cache:
           keys:
-            - v2435-linux-{{ checksum ".circleci/config.yml" }}
-            - v2435-linux-{{ .Branch }}
-            - v2435-linux-main
+            - v2445-linux-{{ checksum ".circleci/config.yml" }}
+            - v2445-linux-{{ .Branch }}
+            - v2445-linux-main
       - run:
           name: "Install APT packages"
           command: |
@@ -72,11 +72,11 @@ jobs:
           working_directory: vcpkg
           no_output_timeout: 1h
       - save_cache:
-          key: v2435-linux-{{ .Branch }}
+          key: v2445-linux-{{ .Branch }}
           paths:
             - /tmp/vcpkg-caches
       - save_cache:
-          key: v2435-linux-{{ checksum ".circleci/config.yml" }}
+          key: v2445-linux-{{ checksum ".circleci/config.yml" }}
           paths:
             - /tmp/vcpkg-caches
       - store_artifacts:
@@ -85,7 +85,7 @@ jobs:
 
   arm64_android:
     docker: # https://circleci.com/developer/images/image/cimg/android
-      - image: cimg/android:2024.09.1-ndk # 27.0.12077973
+      - image: cimg/android:2024.11.1-ndk # 28.0.12433566
     resource_class: large
     environment:
       VCPKG_DOWNLOADS: /tmp/vcpkg-caches
@@ -95,13 +95,13 @@ jobs:
       - aws-cli/setup # check project variables
       - android/accept-licenses
       - run:
-          name: "Setup: microsoft/vcpkg(2024.08.23)"
+          name: "Setup: microsoft/vcpkg(2024.10.21)"
           command: |
             sudo apt-get update -y -q
             sudo apt-get install -y -q curl zip unzip tar
             mkdir -p $VCPKG_DOWNLOADS
             mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-            git clone --branch=2024.08.23 --depth=1 https://github.com/microsoft/vcpkg
+            git clone --branch=2024.10.21 --depth=1 https://github.com/microsoft/vcpkg
             pushd vcpkg
               ./bootstrap-vcpkg.sh
             popd

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/cache@v4.0.2
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.06.15"
-            vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
-          - vcpkg_tag: "2024.07.12"
-            vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
           - vcpkg_tag: "2024.08.23"
             vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
+          - vcpkg_tag: "2024.09.30"
+            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
+          - vcpkg_tag: "2024.10.21"
+            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/cache@v4.0.2
         with:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.06.15"
-            vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
-          - vcpkg_tag: "2024.07.12"
-            vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
           - vcpkg_tag: "2024.08.23"
             vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
+          - vcpkg_tag: "2024.09.30"
+            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
+          - vcpkg_tag: "2024.10.21"
+            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.06.15"
-            vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
           - vcpkg_tag: "2024.07.12"
             vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
           - vcpkg_tag: "2024.08.23"
             vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
-          - vcpkg_tag: "2024.09.23"
-            vcpkg_commit: "f176b58f35a75f9f8f54099cd9df97d2e2793a2e"
+          - vcpkg_tag: "2024.09.30"
+            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
+          - vcpkg_tag: "2024.10.21"
+            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
@@ -103,12 +103,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.06.15"
-            vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
-          - vcpkg_tag: "2024.08.23"
-            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
-          - vcpkg_tag: "2024.09.23"
-            vcpkg_commit: "f176b58f35a75f9f8f54099cd9df97d2e2793a2e"
+          - vcpkg_tag: "2024.09.30"
+            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
+          - vcpkg_tag: "2024.10.21"
+            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
@@ -168,12 +166,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.06.15"
-            vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
-          - vcpkg_tag: "2024.08.23"
-            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
-          - vcpkg_tag: "2024.09.23"
-            vcpkg_commit: "f176b58f35a75f9f8f54099cd9df97d2e2793a2e"
+          - vcpkg_tag: "2024.09.30"
+            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
+          - vcpkg_tag: "2024.10.21"
+            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: "Enalbe LongPath"
         run: git config --system core.longpaths true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.06.15"
-            vcpkg_commit: "f7423ee180c4b7f40d43402c2feb3859161ef625"
-          - vcpkg_tag: "2024.07.12"
-            vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
           - vcpkg_tag: "2024.08.23"
             vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
+          - vcpkg_tag: "2024.09.30"
+            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
+          - vcpkg_tag: "2024.10.21"
+            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ schedules:
 variables:
   # check https://github.com/microsoft/vcpkg/releases
   - name: vcpkg.version
-    value: "2024.09.30"
+    value: "2024.10.21"
 
   - name: vcpkg.overlay.ports # == VCPKG_OVERLAY_PORTS
     value: $(Build.SourcesDirectory)/ports # --overlay-ports $(Build.SourcesDirectory)/ports
@@ -63,9 +63,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2439-bin-uwp" | "$(vcpkg.default.triplet)"'
+              key: '"v2445-bin-uwp" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2439-bin-uwp" | "$(vcpkg.default.triplet)"
+                "v2445-bin-uwp" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: arm64-windows"
@@ -124,9 +124,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2439-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"'
+              key: '"v2445-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"'
               restoreKeys: |
-                "v2439-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"
+                "v2445-bin-ubuntu" | "$(vcpkg.default.triplet)_$(cc)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: $(cxx)"
@@ -166,9 +166,9 @@ stages:
           - powershell: New-Item -Type Directory -Force "$env:VCPKG_DEFAULT_BINARY_CACHE"
           - task: Cache@2
             inputs:
-              key: '"v2439-bin-android" | "$(vcpkg.default.triplet)"'
+              key: '"v2445-bin-android" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2439-bin-android" | "$(vcpkg.default.triplet)"
+                "v2445-bin-android" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: $(vcpkg.default.triplet)"
@@ -224,9 +224,9 @@ stages:
               targetType: 'inline'
           - task: Cache@2
             inputs:
-              key: '"v2439-bin-osx" | "$(vcpkg.default.triplet)"'
+              key: '"v2445-bin-osx" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2439-bin-osx" | "$(vcpkg.default.triplet)"
+                "v2445-bin-osx" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: osx"
@@ -279,9 +279,9 @@ stages:
               targetType: 'inline'
           - task: Cache@2
             inputs:
-              key: '"v2439-bin-ios" | "$(vcpkg.default.triplet)"'
+              key: '"v2445-bin-ios" | "$(vcpkg.default.triplet)"'
               restoreKeys: |
-                "v2439-bin-ios" | "$(vcpkg.default.triplet)"
+                "v2445-bin-ios" | "$(vcpkg.default.triplet)"
               path: $(vcpkg.default.binary.cache)
           - task: PowerShell@2
             displayName: "Test: $(vcpkg.default.triplet)"


### PR DESCRIPTION
### Changes

* Update the vcpkg tag/commit
* Update the cache keys

### References

* https://github.com/microsoft/vcpkg/releases/tag/2024.10.21
* https://github.com/microsoft/vcpkg/releases/tag/2024.09.30
