### PR TITLE
[openssl3] fixup OpenSSLConfig.cmake with vcpkg-cmake-config

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -176,6 +176,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     include("${CMAKE_CURRENT_LIST_DIR}/install-pc-files.cmake")
 endif()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/OpenSSL" PACKAGE_NAME OpenSSL)
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES openssl AUTO_CLEAN)

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,9 +1,16 @@
 {
   "name": "openssl3",
   "version-semver": "3.3.2",
+  "port-version": 1,
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "tools": {
       "description": "Buind/Install OpenSSL CLI tools",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -178,7 +178,7 @@
     },
     "openssl3": {
       "baseline": "3.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "psimd": {
       "baseline": "2020-05-17",

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75624b98557e205222fa0df609897aaa73a0209c",
+      "version-semver": "3.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "4f69fff31d0114703d35d4df17e613da05c63e9c",
       "version-semver": "3.3.2",
       "port-version": 0


### PR DESCRIPTION
### Changes

Run fixup function after installtation

```cmake
vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/OpenSSL" PACKAGE_NAME OpenSSL)
```

### References

* https://github.com/openssl/openssl/commit/c768ccebc718ea0ed6afc5147fe4079fff632cd6
