### PR TITLE
[openssl3] Update to 3.4.0

### DIFF
--- a/ports/openssl3/portfile.cmake
+++ b/ports/openssl3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
-    REF openssl-3.3.2
-    SHA512 c6c152fa3eb06c8dcd4de9fccfd42165ba98715cc560454930709554bcb060db5a8465b70ee1d53e6df6ddc85507f66da745b1f2e2fae9605d808ea861d8f57d
+    REF openssl-${VERSION}
+    SHA512 d5f78b2e9d7b7b4787c976c4f832b1448bbadf5f9d398a50ef98053f92501768d000aa73673af200568aef4c8a491442ebbee8c43556838f465d4f91dfc2b5ad
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openssl3/vcpkg.json
+++ b/ports/openssl3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl3",
-  "version-semver": "3.3.2",
-  "port-version": 1,
+  "version-semver": "3.4.0",
   "description": "TLS/SSL and crypto library",
   "homepage": "https://www.openssl.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -177,8 +177,8 @@
       "port-version": 1
     },
     "openssl3": {
-      "baseline": "3.3.2",
-      "port-version": 1
+      "baseline": "3.4.0",
+      "port-version": 0
     },
     "psimd": {
       "baseline": "2020-05-17",

--- a/versions/o-/openssl3.json
+++ b/versions/o-/openssl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3909763e93d4a25f40d5d9b6cbe1ba8c876cfff1",
+      "version-semver": "3.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "75624b98557e205222fa0df609897aaa73a0209c",
       "version-semver": "3.3.2",
       "port-version": 1


### PR DESCRIPTION
### Changes

* Update to the later version

### References

* https://github.com/openssl/openssl/releases/tag/openssl-3.4.0
* #248
