### PR TITLE
[google-jni-bind] Update to 1.1.2-beta

### DIFF
--- a/ports/google-jni-bind/portfile.cmake
+++ b/ports/google-jni-bind/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/jni-bind
-    REF Release-1.1.0-beta
-    SHA512 ffc011eb1d812360b844ff413ead8eb2c98080264655f7e1e30d9cf8f869875da02882559f147156279f6aa86ceba8a4660ca9fda637ac59d417ceaf4d76330d
+    REF Release-${VERSION}
+    SHA512 ef96ea568857ff562d2d55c6d62f5fbe7b2d914beaeea0246af3da881a6b6a39925d4ac48754cc87683b48bf8673e8fe1bca57ad71a5e789e8fb76c192eb0801
     HEAD_REF main
 )
 # Install headers and a shim library with JackWeakAPI.c

--- a/ports/google-jni-bind/vcpkg.json
+++ b/ports/google-jni-bind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-jni-bind",
-  "version-semver": "1.1.0-beta",
+  "version-semver": "1.1.2-beta",
   "description": "JNI Bind is a set of advanced syntactic sugar for writing efficient correct JNI Code in C++17 (and up)",
   "homepage": "https://github.com/google/jni-bind",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -77,7 +77,7 @@
       "port-version": 0
     },
     "google-jni-bind": {
-      "baseline": "1.1.0-beta",
+      "baseline": "1.1.2-beta",
       "port-version": 0
     },
     "libdispatch": {

--- a/versions/g-/google-jni-bind.json
+++ b/versions/g-/google-jni-bind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "765b8315fd112e2016afc365ff6828da6625b56b",
+      "version-semver": "1.1.2-beta",
+      "port-version": 0
+    },
+    {
       "git-tree": "d0a27c1f78f84ffde56cbf6299f66dfdad09bbb8",
       "version-semver": "1.1.0-beta",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Update to the later version

### References

* https://github.com/google/jni-bind/releases/tag/Release-1.1.2-beta
* #228 
