### PR TITLE
[tensorpipe] better `find_package`, `find_dependency` for libuv

### DIFF
--- a/ports/tensorpipe/TensorpipeConfig.cmake.in
+++ b/ports/tensorpipe/TensorpipeConfig.cmake.in
@@ -5,6 +5,8 @@ file(GLOB CONFIG_FILES "${_DIR}/TensorpipeConfig-*.cmake")
 foreach(f ${CONFIG_FILES})
   include(${f})
 endforeach()
+include(CMakeFindDependencyMacro)
+find_dependency(libuv)
 
 # ${_DIR}/TensorpipeTargets-*.cmake will be included here
 include("${_DIR}/TensorpipeTargets.cmake")

--- a/ports/tensorpipe/fix-cmakelists.patch
+++ b/ports/tensorpipe/fix-cmakelists.patch
@@ -26,7 +26,7 @@ index 5c36064..cfaf0bc 100644
 -list(APPEND TP_LINK_LIBRARIES uv::uv)
 +# `libuv` in vcpkg
 +find_package(libuv CONFIG REQUIRED) 
-+list(APPEND TP_LINK_LIBRARIES libuv::uv)
++list(APPEND TP_LINK_LIBRARIES $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>)
  
  ### shm
  

--- a/ports/tensorpipe/vcpkg.json
+++ b/ports/tensorpipe/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tensorpipe",
   "version-date": "2022-05-14",
+  "port-version": 1,
   "description": "A tensor-aware point-to-point communication primitive for machine learning",
   "homepage": "https://github.com/pytorch/tensorpipe",
   "supports": "linux | osx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -214,7 +214,7 @@
     },
     "tensorpipe": {
       "baseline": "2022-05-14",
-      "port-version": 0
+      "port-version": 1
     },
     "winpixeventruntime": {
       "baseline": "1.0.240308001",

--- a/versions/t-/tensorpipe.json
+++ b/versions/t-/tensorpipe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bea628bab64b103a657c4bb95082e505ed8ec1c",
+      "version-date": "2022-05-14",
+      "port-version": 1
+    },
+    {
       "git-tree": "2db63d9b007bc20c99bd76d48c2ccf80f6bc4a6a",
       "version-date": "2022-05-14",
       "port-version": 0

--- a/versions/t-/tensorpipe.json
+++ b/versions/t-/tensorpipe.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bea628bab64b103a657c4bb95082e505ed8ec1c",
+      "git-tree": "c63be39eb3e399f41f96fbd39bfa1530951bde15",
       "version-date": "2022-05-14",
       "port-version": 1
     },


### PR DESCRIPTION
### Changes

Automatically finds `libuv`

```cmake
find_package(Tensorpipe) # find_dependency(libuv)
```


### References

* https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#config-file-packages
* https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html
