### PR TITLE
[opencl-on-dx12] Fix D3D12TransitionLayer build failure

### DIFF
--- a/ports/opencl-on-dx12/fix-d3d12transitionlayer.patch
+++ b/ports/opencl-on-dx12/fix-d3d12transitionlayer.patch
@@ -1,0 +1,12 @@
+diff --git a/src/d3d12translationlayer/ImmediateContext.cpp b/src/d3d12translationlayer/ImmediateContext.cpp
+index 77351d0..38e6486 100644
+--- a/src/d3d12translationlayer/ImmediateContext.cpp
++++ b/src/d3d12translationlayer/ImmediateContext.cpp
+@@ -5,6 +5,7 @@
+ #include "ImmediateContext.inl"
+ #include "FormatDesc.hpp"
+ #include "View.inl"
++#include <algorithm>
+ 
+ namespace D3D12TranslationLayer
+ {

--- a/ports/opencl-on-dx12/portfile.cmake
+++ b/ports/opencl-on-dx12/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     SHA512 7053cee9db381b55bab74729fa445b485e70f6c71f3358824ffae5aa4dfc6e869825196c029d94582a8b1d88029a508e7e38a24ffe9adafb242725a790f7f3e5
     PATCHES
         fix-cmake.patch
+        fix-d3d12transitionlayer.patch
     HEAD_REF master
 )
 

--- a/ports/opencl-on-dx12/vcpkg.json
+++ b/ports/opencl-on-dx12/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencl-on-dx12",
   "version": "1.2404.1.0",
+  "port-version": 1,
   "description": "The OpenCL-on-D3D12 mapping layer",
   "homepage": "https://github.com/microsoft/OpenCLOn12",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -162,7 +162,7 @@
     },
     "opencl-on-dx12": {
       "baseline": "1.2404.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openjdk": {
       "baseline": "jdk-23+10",

--- a/versions/o-/opencl-on-dx12.json
+++ b/versions/o-/opencl-on-dx12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e87c7ae6553d1f40a1b82282b434a99a049eed5e",
+      "version": "1.2404.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1eb20287e0d42eead0d7038861b0aa40a2159641",
       "version": "1.2404.1.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

`<algorithm>` header is required to use `std::generator_n`

### References

* https://en.cppreference.com/w/cpp/algorithm/generate_n
