### PR TITLE
CI: workflow update with vcpkg 2025.01.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
 jobs:
   arm64_android:
     docker: # https://circleci.com/developer/images/image/cimg/android
-      - image: cimg/android:2024.11.1-ndk # 28.0.12433566
+      - image: cimg/android:2025.01.1-ndk # 28.0.12674087
     resource_class: large
     environment:
       VCPKG_DOWNLOADS: /tmp/vcpkg-caches
@@ -30,13 +30,13 @@ jobs:
       - android/change_java_version:
           java_version: 17
       - run:
-          name: "Setup: microsoft/vcpkg(2024.10.21)"
+          name: "Setup: microsoft/vcpkg(2025.01.13)"
           command: |
             sudo apt-get update -y -q
             sudo apt-get install -y -q curl zip unzip tar
             mkdir -p $VCPKG_DOWNLOADS
             mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-            git clone --branch=2024.10.21 --depth=1 https://github.com/microsoft/vcpkg
+            git clone --branch=2025.01.13 --depth=1 https://github.com/microsoft/vcpkg
             pushd vcpkg
               ./bootstrap-vcpkg.sh
             popd
@@ -46,9 +46,9 @@ jobs:
             VCPKG_ROOT: /tmp/vcpkg
       - restore_cache:
           keys:
-            - v2445-android-{{ checksum ".circleci/config.yml" }}
-            - v2445-android-{{ .Branch }}
-            - v2445-android-main
+            - 2504-android-{{ checksum ".circleci/config.yml" }}
+            - 2504-android-{{ .Branch }}
+            - 2504-android-main
       - run:
           name: "Install: port-android.txt"
           command: |
@@ -67,11 +67,11 @@ jobs:
             VCPKG_MAX_CONCURRENCY: 2
           no_output_timeout: 1h
       - save_cache:
-          key: v2445-android-{{ .Branch }}
+          key: 2504-android-{{ .Branch }}
           paths:
             - /tmp/vcpkg-caches
       - save_cache:
-          key: v2445-android-{{ checksum ".circleci/config.yml" }}
+          key: 2504-android-{{ checksum ".circleci/config.yml" }}
           paths:
             - /tmp/vcpkg-caches
       - store_artifacts:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.10.21"
-            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
+          - vcpkg_tag: "2025.01.13"
+            vcpkg_commit: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/cache@v4.2.0
         with:
-          key: "v2432-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
+          key: "v2504-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
           path: |
             ${{ runner.temp }}/vcpkg-downloads
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -28,9 +28,9 @@ jobs:
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/triplets
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: ConorMacBride/install-package@v1.1.0
-        with:
-          brew: autoconf automake libtool
+
+      - name: "Run homebrew"
+        run: brew install autoconf automake libtool
 
       - uses: mobiledevops/xcode-select-version-action@v1.0.0
         with:
@@ -46,7 +46,7 @@ jobs:
         with:
           key: "v2504-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
           path: |
-            ${{ runner.temp }}/vcpkg-downloads
+            ${{ runner.temp }}/vcpkg-caches
 
       - name: "Create cache folders"
         shell: bash
@@ -56,29 +56,33 @@ jobs:
           VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
 
       - uses: lukka/run-vcpkg@v11.5
-        name: "Run vcpkg(x64-osx)"
         with:
-          vcpkgDirectory: "/usr/local/share/vcpkg" # see VCPKG_INSTALLATION_ROOT
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg" # ignore VCPKG_INSTALLATION_ROOT
           vcpkgGitCommitId: "${{ matrix.vcpkg_commit }}"
-          vcpkgJsonGlob: "test/vcpkg.json"
-          vcpkgConfigurationJsonGlob: "test/vcpkg-configuration.json"
-          runVcpkgInstall: true
-          runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`, `--x-feature`, `test`]'
-        env:
-          VCPKG_DEFAULT_TRIPLET: "x64-osx"
-          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
-          VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
+          runVcpkgInstall: false
 
-      - uses: lukka/run-vcpkg@v11.5
-        name: "Run vcpkg(arm64-osx)"
-        with:
-          vcpkgDirectory: "/usr/local/share/vcpkg" # see VCPKG_INSTALLATION_ROOT
-          vcpkgGitCommitId: "${{ matrix.vcpkg_commit }}"
-          vcpkgJsonGlob: "test/vcpkg.json"
-          vcpkgConfigurationJsonGlob: "test/vcpkg-configuration.json"
-          runVcpkgInstall: true
-          runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`, `--x-feature`, `test`]'
+      - name: "Run vcpkg(x64-osx)"
+        run: |
+          mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build \
+            --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
         env:
+          VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-caches"
+          VCPKG_DEFAULT_TRIPLET: "x64-osx"
+          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
+
+      - name: "Run vcpkg(arm64-osx)"
+        run: |
+          mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build \
+            --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-caches"
           VCPKG_DEFAULT_TRIPLET: "arm64-osx"
-          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
-          VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
+          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -65,7 +65,8 @@ jobs:
           VCPKG_DEFAULT_TRIPLET: "x64-linux"
           VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
 
-      - name: "Run vcpkg(arm64-linux)"
+      - name: "Run vcpkg(arm64-linux)" # skip for now
+        if: ${{ false }}
         run: |
           mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
           vcpkg install --keep-going \

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.10.21"
-            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
+          - vcpkg_tag: "2025.01.13"
+            vcpkg_commit: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/cache@v4.2.0
         with:
-          key: "v2432-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
+          key: "v2504-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
           path: |
             ${{ runner.temp }}/vcpkg-downloads
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -28,9 +28,11 @@ jobs:
       VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: ConorMacBride/install-package@v1.1.0
-        with:
-          apt: nuget nasm libnuma-dev libopenmpi-dev libx11-dev libxi-dev libxext-dev libx11-xcb-dev
+
+      - name: "Run apt"
+        run: |
+          # sudo apt update -y
+          sudo apt install -y nasm libnuma-dev libopenmpi-dev libx11-dev libxi-dev libxext-dev libx11-xcb-dev
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -42,40 +44,36 @@ jobs:
         with:
           key: "v2504-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
           path: |
-            ${{ runner.temp }}/vcpkg-downloads
+            ${{ runner.temp }}/vcpkg-caches
 
-      - name: "Create cache folders"
-        shell: bash
+      - uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg" # ignore VCPKG_INSTALLATION_ROOT
+          vcpkgGitCommitId: "${{ matrix.vcpkg_commit }}"
+          runVcpkgInstall: false
+
+      - name: "Run vcpkg(x64-linux)"
         run: |
-          mkdir -p ${VCPKG_DOWNLOADS}
+          mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build \
+            --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
         env:
-          VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
-
-      - uses: lukka/run-vcpkg@v11.5
-        name: "Run vcpkg(x64-linux)"
-        with:
-          vcpkgDirectory: "${{ runner.temp }}/vcpkg" # ignore VCPKG_INSTALLATION_ROOT
-          vcpkgGitCommitId: "${{ matrix.vcpkg_commit }}"
-          vcpkgJsonGlob: "test/vcpkg.json"
-          vcpkgConfigurationJsonGlob: "test/vcpkg-configuration.json"
-          runVcpkgInstall: true
-          runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`, `--x-feature`, `test`]'
-        env:
+          VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-caches"
           VCPKG_DEFAULT_TRIPLET: "x64-linux"
-          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
-          VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
+          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
 
-      - uses: lukka/run-vcpkg@v11.5
-        name: "Run vcpkg(arm64-linux)" # It's for future works. Not ready yet...
-        if: ${{ false }}
-        with:
-          vcpkgDirectory: "${{ runner.temp }}/vcpkg" # ignore VCPKG_INSTALLATION_ROOT
-          vcpkgGitCommitId: "${{ matrix.vcpkg_commit }}"
-          vcpkgJsonGlob: "test/vcpkg.json"
-          vcpkgConfigurationJsonGlob: "test/vcpkg-configuration.json"
-          runVcpkgInstall: true
-          runVcpkgFormatString: '[`install`, `--keep-going`, `--clean-buildtrees-after-build`, `--clean-packages-after-build`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`, `--x-feature`, `test`]'
+      - name: "Run vcpkg(arm64-linux)"
+        run: |
+          mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build \
+            --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
         env:
+          VCPKG_DEFAULT_BINARY_CACHE: "${{ runner.temp }}/vcpkg-caches"
           VCPKG_DEFAULT_TRIPLET: "arm64-linux"
-          VCPKG_BINARY_SOURCES: ${{ secrets.VCPKG_BINARY_SOURCES }}
-          VCPKG_DOWNLOADS: "${{ runner.temp }}/vcpkg-downloads"
+          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -35,16 +35,6 @@ jobs:
         with:
           msbuild-architecture: x64
 
-      - uses: ConorMacBride/install-package@v1.1.0
-        with:
-          choco: awscli
-
-      - name: "Update environment"
-        run: |
-          Write-Output "PATH=$env:PATH;C:\Program Files\Amazon\AWSCLIV2" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          New-Item -Type Directory -Force C:/vcpkg-caches
-        shell: pwsh
-
       - name: "Enable LongPath"
         run: |
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
@@ -53,7 +43,9 @@ jobs:
         continue-on-error: true
 
       - name: "Change vcpkg.json"
-        run: Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
+        run: |
+          New-Item -Type Directory -Force C:/vcpkg-caches
+          Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
         shell: pwsh
 
       - uses: lukka/run-vcpkg@v11.5
@@ -111,16 +103,6 @@ jobs:
         with:
           msbuild-architecture: x64
 
-      - uses: ConorMacBride/install-package@v1.1.0
-        with:
-          choco: awscli
-
-      - name: "Update environment"
-        run: |
-          Write-Output "PATH=$env:PATH;C:\Program Files\Amazon\AWSCLIV2" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          New-Item -Type Directory -Force C:/vcpkg-caches
-        shell: pwsh
-
       - name: "Enable LongPath"
         run: |
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
@@ -129,7 +111,9 @@ jobs:
         continue-on-error: true
 
       - name: "Change vcpkg.json"
-        run: Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
+        run: |
+          New-Item -Type Directory -Force C:/vcpkg-caches
+          Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
         shell: pwsh
 
       - uses: lukka/run-vcpkg@v11.5
@@ -172,16 +156,6 @@ jobs:
         with:
           msbuild-architecture: x64
 
-      - uses: ConorMacBride/install-package@v1.1.0
-        with:
-          choco: awscli
-
-      - name: "Update environment"
-        run: |
-          Write-Output "PATH=$env:PATH;C:\Program Files\Amazon\AWSCLIV2" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          New-Item -Type Directory -Force C:/vcpkg-caches
-        shell: pwsh
-
       - uses: humbletim/install-vulkan-sdk@v1.1.1 # install Vulkan sdk if env.VULKAN_SDK is empty
         if: env.VULKAN_SDK == ''
         with:
@@ -197,7 +171,9 @@ jobs:
         continue-on-error: true
 
       - name: "Change vcpkg.json"
-        run: Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
+        run: |
+          New-Item -Type Directory -Force C:/vcpkg-caches
+          Move-Item -Path "test/self-hosted.json" -Destination "test/vcpkg.json" -Force
         shell: pwsh
 
       - uses: lukka/run-vcpkg@v11.5

--- a/.github/workflows/build-windows-hosted.yml
+++ b/.github/workflows/build-windows-hosted.yml
@@ -21,14 +21,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.07.12"
-            vcpkg_commit: "1de2026f28ead93ff1773e6e680387643e914ea1"
-          - vcpkg_tag: "2024.08.23"
-            vcpkg_commit: "3508985146f1b1d248c67ead13f8f54be5b4f5da"
-          - vcpkg_tag: "2024.09.30"
-            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
           - vcpkg_tag: "2024.10.21"
             vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
+          - vcpkg_tag: "2025.01.13"
+            vcpkg_commit: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
@@ -103,10 +99,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.09.30"
-            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
-          - vcpkg_tag: "2024.10.21"
-            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
+          - vcpkg_tag: "2025.01.13"
+            vcpkg_commit: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
@@ -166,10 +160,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.09.30"
-            vcpkg_commit: "c82f74667287d3dc386bce81e44964370c91a289"
-          - vcpkg_tag: "2024.10.21"
-            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
+          - vcpkg_tag: "2025.01.13"
+            vcpkg_commit: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
       fail-fast: false
     env:
       VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - vcpkg_tag: "2024.10.21"
-            vcpkg_commit: "10b7a178346f3f0abef60cecd5130e295afd8da4"
+          - vcpkg_tag: "2025.01.13"
+            vcpkg_commit: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
       fail-fast: false
     env:
       VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/cache@v4.2.0
         with:
-          key: "v2432-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
+          key: "v2504-${{ runner.os }}-${{ matrix.vcpkg_tag }}"
           path: |
             ${{ runner.temp }}/vcpkg-downloads
 

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -67,5 +67,11 @@
         "vulkan-headers"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "fmt",
+      "version": "9.1.0#1"
+    }
+  ]
 }

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2024-11-17",
+  "version-date": "2025-01-26",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows",
@@ -30,14 +30,7 @@
         "nvidia-tools-extension-sdk",
         "nvidia-triton-client",
         "nvidia-triton-common",
-        "nvidia-triton-core",
-        {
-          "name": "onnxruntime",
-          "features": [
-            "cuda",
-            "tensorrt"
-          ]
-        }
+        "nvidia-triton-core"
       ]
     },
     "test": {
@@ -57,14 +50,6 @@
             "disable-static-registration",
             "test"
           ]
-        },
-        {
-          "name": "onnxruntime",
-          "features": [
-            "test",
-            "training"
-          ],
-          "platform": "windows"
         },
         {
           "name": "winpixeventruntime",

--- a/test/vcpkg-configuration.json
+++ b/test/vcpkg-configuration.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/Microsoft/vcpkg",
+    "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836"
+  },
+  "registries": []
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -56,17 +56,6 @@
       ]
     },
     {
-      "name": "onnxruntime",
-      "platform": "linux"
-    },
-    {
-      "name": "onnxruntime",
-      "features": [
-        "coreml"
-      ],
-      "platform": "osx | ios"
-    },
-    {
       "name": "opencl",
       "platform": "windows | linux"
     },


### PR DESCRIPTION
### Changes

Prepare upcoming release of Feburary.

* Excluded `onnxruntime`
* CUDA failure is a known issue

### References

* https://github.com/microsoft/vcpkg/releases/tag/2025.01.13

### Triplet Support

If there is a change in the triplet support, please note it.

* Disabled `arm64-linux`
