### PR TITLE
[llama-cpp] Use later version with several GPU features

### DIFF
--- a/ports/llama-cpp/fix-3rdparty.patch
+++ b/ports/llama-cpp/fix-3rdparty.patch
@@ -1,0 +1,87 @@
+diff --git a/common/CMakeLists.txt b/common/CMakeLists.txt
+index e61015d..3bfac20 100644
+--- a/common/CMakeLists.txt
++++ b/common/CMakeLists.txt
+@@ -64,7 +64,6 @@ add_library(${TARGET} STATIC
+     console.cpp
+     console.h
+     json-schema-to-grammar.cpp
+-    json.hpp
+     llguidance.cpp
+     log.cpp
+     log.h
+@@ -77,6 +76,9 @@ add_library(${TARGET} STATIC
+     speculative.h
+     )
+ 
++find_package(nlohmann_json CONFIG REQUIRED)
++target_link_libraries(${TARGET} PRIVATE nlohmann_json::nlohmann_json)
++
+ if (BUILD_SHARED_LIBS)
+     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ endif()
+diff --git a/common/chat-template.hpp b/common/chat-template.hpp
+index 0e88fb3..1be8519 100644
+--- a/common/chat-template.hpp
++++ b/common/chat-template.hpp
+@@ -9,7 +9,7 @@
+ #pragma once
+ 
+ #include "minja.hpp"
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/common/chat.hpp b/common/chat.hpp
+index 33e64a4..7e2f658 100644
+--- a/common/chat.hpp
++++ b/common/chat.hpp
+@@ -3,7 +3,7 @@
+ #pragma once
+ 
+ #include "common.h"
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+ #include <optional>
+ #include <string>
+ #include <vector>
+diff --git a/common/common.cpp b/common/common.cpp
+index 8661e16..6b9d80a 100644
+--- a/common/common.cpp
++++ b/common/common.cpp
+@@ -9,7 +9,7 @@
+ #include "log.h"
+ // Change JSON_ASSERT from assert() to GGML_ASSERT:
+ #define JSON_ASSERT GGML_ASSERT
+-#include "json.hpp"
++#include <nlohmann/json.hpp>
+ #include "json-schema-to-grammar.h"
+ #include "llama.h"
+ #include "chat.hpp"
+diff --git a/common/json-schema-to-grammar.h b/common/json-schema-to-grammar.h
+index 62a3b0a..81fdcff 100644
+--- a/common/json-schema-to-grammar.h
++++ b/common/json-schema-to-grammar.h
+@@ -3,7 +3,7 @@
+ #include "ggml.h"
+ // Change JSON_ASSERT from assert() to GGML_ASSERT:
+ #define JSON_ASSERT GGML_ASSERT
+-#include "json.hpp"
++#include <nlohmann/json.hpp>
+ 
+ std::string json_schema_to_grammar(const nlohmann::ordered_json & schema,
+                                    bool force_gbnf = false);
+diff --git a/common/minja.hpp b/common/minja.hpp
+index c304b5c..1480087 100644
+--- a/common/minja.hpp
++++ b/common/minja.hpp
+@@ -16,7 +16,7 @@
+ #include <stdexcept>
+ #include <sstream>
+ #include <unordered_set>
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+ 
+ using json = nlohmann::ordered_json;
+ 

--- a/ports/llama-cpp/fix-3rdparty.patch
+++ b/ports/llama-cpp/fix-3rdparty.patch
@@ -85,3 +85,53 @@ index c304b5c..1480087 100644
  
  using json = nlohmann::ordered_json;
  
+diff --git a/examples/server/CMakeLists.txt b/examples/server/CMakeLists.txt
+index 1b7cc8c..e1a9cad 100644
+--- a/examples/server/CMakeLists.txt
++++ b/examples/server/CMakeLists.txt
+@@ -12,7 +12,6 @@ endif()
+ set(TARGET_SRCS
+     server.cpp
+     utils.hpp
+-    httplib.h
+ )
+ set(PUBLIC_ASSETS
+     index.html.gz
+@@ -34,7 +33,10 @@ endforeach()
+ add_executable(${TARGET} ${TARGET_SRCS})
+ install(TARGETS ${TARGET} RUNTIME)
+ 
+-target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
++# find_path(CPPHTTPLIB_INCLUDE_DIRS NAMES "httplib.h" REQUIRED)
++target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR} ${CPPHTTPLIB_INCLUDE_DIRS})
++find_package(CURL REQUIRED)
++target_link_libraries(${TARGET} PRIVATE CURL::libcurl)
+ target_link_libraries(${TARGET} PRIVATE common ${CMAKE_THREAD_LIBS_INIT})
+ 
+ if (LLAMA_SERVER_SSL)
+diff --git a/examples/server/server.cpp b/examples/server/server.cpp
+index 9cdf205..bfc05bc 100644
+--- a/examples/server/server.cpp
++++ b/examples/server/server.cpp
+@@ -10,7 +10,7 @@
+ 
+ // Change JSON_ASSERT from assert() to GGML_ASSERT:
+ #define JSON_ASSERT GGML_ASSERT
+-#include "json.hpp"
++#include <nlohmann/json.hpp>
+ // mime type for sending response
+ #define MIMETYPE_JSON "application/json; charset=utf-8"
+ 
+diff --git a/examples/server/utils.hpp b/examples/server/utils.hpp
+index 5f97df5..db2a42f 100644
+--- a/examples/server/utils.hpp
++++ b/examples/server/utils.hpp
+@@ -11,7 +11,7 @@
+ 
+ // Change JSON_ASSERT from assert() to GGML_ASSERT:
+ #define JSON_ASSERT GGML_ASSERT
+-#include "json.hpp"
++#include <nlohmann/json.hpp>
+ #include "minja.hpp"
+ #include "chat.hpp"
+ #include "chat-template.hpp"

--- a/ports/llama-cpp/fix-cmake-ggml.patch
+++ b/ports/llama-cpp/fix-cmake-ggml.patch
@@ -1,0 +1,22 @@
+diff --git a/ggml/CMakeLists.txt b/ggml/CMakeLists.txt
+index 75b5ea3..96b5423 100644
+--- a/ggml/CMakeLists.txt
++++ b/ggml/CMakeLists.txt
+@@ -17,7 +17,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+     # configure project version
+     # TODO
+ else()
+-    set(GGML_STANDALONE OFF)
++    option(GGML_STANDALONE "ggml: standalone build" OFF)
+ endif()
+ 
+ if (EMSCRIPTEN)
+@@ -259,7 +259,7 @@ set_target_properties(ggml PROPERTIES PUBLIC_HEADER "${GGML_PUBLIC_HEADERS}")
+ install(TARGETS ggml LIBRARY PUBLIC_HEADER)
+ install(TARGETS ggml-base LIBRARY)
+ 
+-if (GGML_STANDALONE)
++if (FALSE)
+     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ggml.pc.in
+         ${CMAKE_CURRENT_BINARY_DIR}/ggml.pc
+         @ONLY)

--- a/ports/llama-cpp/fix-cmake-llama.patch
+++ b/ports/llama-cpp/fix-cmake-llama.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 74b48d2..172c5d9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -169,6 +169,9 @@ if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
+     add_subdirectory(tests)
+ endif()
+ 
++if (LLAMA_BUILD_SERVER)
++    add_subdirectory(examples/server)
++endif()
+ if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_EXAMPLES)
+     add_subdirectory(examples)
+     add_subdirectory(pocs)
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index 66cfab2..9df5985 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -41,9 +41,6 @@ else()
+     add_subdirectory(perplexity)
+     add_subdirectory(quantize)
+     add_subdirectory(retrieval)
+-    if (LLAMA_BUILD_SERVER)
+-        add_subdirectory(server)
+-    endif()
+     add_subdirectory(save-load-state)
+     add_subdirectory(run)
+     add_subdirectory(simple)

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -46,10 +46,17 @@ if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     list(APPEND ARCH_OPTIONS
         -DGGML_AARCH64=ON
     )
+    if(VCPKG_TARGET_IS_WINDOWS)
+        # ggml-cpu: MSVC is not supported for ARM, use clang
+        # Visual Studio with ClangCL
+        set(VCPKG_PLATFORM_TOOLSET ClangCL) # see CMAKE_GENERATOR_TOOLSET
+        set(GENERATOR_OPTIONS WINDOWS_USE_MSBUILD)
+    endif()
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    ${GENERATOR_OPTIONS}
     OPTIONS
         ${FEATURE_OPTIONS}
         ${ARCH_OPTIONS}

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -1,104 +1,92 @@
 if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled) # there are some python scripts
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggerganov/llama.cpp
-    REF b1695 # commit 925e5584a058afb612f9c20bc472c130f5d0f891
-    SHA512 3f50216030fe022dbfdcdb7c96765bdf2f1995a4672e7ffbca672fc5f502149d47146428e3f5cdd4799724011b29941826cf66b9178337cce05b8aa0b5292f1c
+    REF "b${VERSION}"
+    SHA512 d939bb35e492dba06068e49dd0b28e8352fcbf598c1d7198fdedb405893b4c3a90b3709f0c57e57ffe3e92860d7c5ad21a2cc1129d50c07f27470b8b37d87183
     HEAD_REF master
+    PATCHES
+        fix-cmake-ggml.patch
 )
 
-vcpkg_find_acquire_program(PKGCONFIG)
-message(STATUS "Using pkgconfig: ${PKGCONFIG}")
+vcpkg_find_acquire_program(GIT)
+message(STATUS "Using git: ${GIT}")
 
-# check https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors
-if(VCPKG_TARGET_IS_WINDOWS)
-    list(APPEND BLAS_OPTIONS -DLLAMA_BLAS_VENDOR=OpenBLAS)
-elseif(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
-    list(APPEND BLAS_OPTIONS -DLLAMA_BLAS_VENDOR=Apple)
-else()
-    # todo: Intel MKL, ARM, ACML, etc...
-    list(APPEND BLAS_OPTIONS -DLLAMA_BLAS_VENDOR=Generic)
-endif()
-
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    list(APPEND ARCH_OPTIONS
-        -DLLAMA_AVX512=ON -DLLAMA_AVX512_VBMI=ON -DLLAMA_AVX512_VNNI=ON
-        # -DLLAMA_AVX2=ON
-        # -DLLAMA_AVX=ON
-    )
-endif()
-
+# for BLAS, see https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        cublas  LLAMA_CUBLAS
-        cublas  LLAMA_CUDA_F16
-        clblast LLAMA_CLBLAST
-        mpi     LLAMA_MPI
-        test    LLAMA_BUILD_TESTS
+        server  LLAMA_BUILD_SERVER
+        server  LLAMA_BUILD_EXAMPLES
+        cuda    LLAMA_CUBLAS
+        cuda    GGML_CUDA
+        cuda    GGML_CUDA_GRAPHS_DEFAULT
+        opencl  GGML_OPENCL
+        openmp  GGML_OPENMP
+        vulkan  GGML_VULKAN
+        vulkan  GGML_VULKAN_CHECK_RESULTS
+        # vulkan  GGML_VULKAN_VALIDATE 
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC)
 
-if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
-    set(TARGET_IS_APPLE ON)
-else()
-    set(TARGET_IS_APPLE OFF)
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    list(APPEND ARCH_OPTIONS
+        -DGGML_AVX2=ON
+        -DGGML_AVX=ON
+        -DGGML_AVX512=ON
+        -DGGML_AVX512_VBMI=ON
+        -DGGML_AVX512_VNNI=ON
+    )
+endif()
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    list(APPEND ARCH_OPTIONS
+        -DGGML_AARCH64=ON
+    )
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${ARCH_OPTIONS}
         ${FEATURE_OPTIONS}
-        -DLLAMA_ACCELERATE=${TARGET_IS_APPLE}
-        -DLLAMA_METAL=${TARGET_IS_APPLE}
-        -DLLAMA_STATIC=${USE_STATIC}
-        -DLLAMA_BLAS=ON
-        ${BLAS_OPTIONS}
-        -DPKG_CONFIG_EXECUTABLE:FILEPATH="${PKGCONFIG}"
-        -DBUILD_COMMIT:STRING="99115f3fa654b593099c6719ad30e3f54ce231e1"
-        -DBUILD_NUMBER:STRING="1695"
+        ${ARCH_OPTIONS}
+        # see cmake/build-info.cmake
+        "-DGIT_EXECUTABLE:FILEPATH=${GIT}"
+        "-DBUILD_NUMBER=${VERSION}"
+        "-DBUILD_COMMIT:STRING=d774ab3acc4fee41fbed6dbfc192b57d5f79f34b"
+        # ${SOURCE_PATH}/CMakeLists.txt
+        -DLLAMA_STANDALONE=ON
+        -DLLAMA_CURL=ON
+        -DLLAMA_LLGUIDANCE=OFF
+        -DLLAMA_ALL_WARNINGS=OFF
+        -DLLAMA_BUILD_TESTS=OFF
+        # ${SOURCE_PATH}/ggml/CMakeLists.txt
+        -DGGML_STANDALONE=ON
+        -DGGML_BUILD_NUMBER=${VERSION}
+        -DGGML_LLAMAFILE_DEFAULT=OFF
+        -DGGML_FATAL_WARNINGS=OFF
+        -DGGML_CPU_ALL_VARIANTS=OFF
+        -DGGML_BACKEND_DL=OFF
+        -DGGML_METAL_USE_BF16=ON
+        -DGGML_METAL_EMBED_LIBRARY=ON
+        -DGGML_OPENMP=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
     OPTIONS_RELEASE
-        -DLLAMA_METAL_NDEBUG=ON
+        -DGGML_METAL_NDEBUG=ON
 )
-vcpkg_cmake_build(TARGET "llama" LOGFILE_BASE build-llama)
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Llama" PACKAGE_NAME "Llama")
-vcpkg_copy_pdbs()
 
-vcpkg_copy_tools(TOOL_NAMES
-    baby-llama beam-search benchmark convert-llama2c-to-ggml embedding llama-bench
-    main perplexity quantize-stats quantize save-load-state server simple speculative train-text-from-scratch    
-    batched-bench batched export-lora finetune infill llava-cli lookahead lookup parallel tokenize
-    AUTO_CLEAN
-)
-if("test" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES
-        test-grad0 test-grammar-parser test-llama-grammar test-quantize-fns test-quantize-perf
-        test-sampling test-tokenizer-0-falcon test-tokenizer-0-llama test-tokenizer-1-llama
-        test-backend-ops test-rope test-tokenizer-1-bpe
-        AUTO_CLEAN
-    )
-endif()
-
-file(INSTALL "${SOURCE_PATH}/llama.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-
-file(INSTALL    "${CURRENT_PACKAGES_DIR}/bin/convert.py"
-                "${CURRENT_PACKAGES_DIR}/bin/convert-lora-to-ggml.py"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
-)
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ggml" PACKAGE_NAME "ggml" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/llama" PACKAGE_NAME "llama")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
-)
-file(REMOVE
-    "${CURRENT_PACKAGES_DIR}/bin/convert.py"
-    "${CURRENT_PACKAGES_DIR}/debug/bin/convert.py"
-    "${CURRENT_PACKAGES_DIR}/bin/convert-lora-to-ggml.py"
-    "${CURRENT_PACKAGES_DIR}/debug/bin/convert-lora-to-ggml.py"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -151,7 +151,6 @@ if("server" IN_LIST FEATURES)
         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/llama.cpp"
     )
 endif()
-vcpkg_copy_tools(TOOL_NAMES convert_hf_to_gguf.py DESTINATION "${CURRENT_PACKAGES_DIR}/tools/llama.cpp" AUTO_CLEAN)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -140,7 +140,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ggml" PACKAGE_NAME "ggml" DO_NOT
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/llama" PACKAGE_NAME "llama")
 
 if("server" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES llama-server DESTINATION "${CURRENT_PACKAGES_DIR}/tools/llama.cpp")
+    vcpkg_copy_tools(TOOL_NAMES llama-server DESTINATION "${CURRENT_PACKAGES_DIR}/tools/llama.cpp" AUTO_CLEAN)
     file(INSTALL
         "${SOURCE_PATH}/examples/server/public"
         "${SOURCE_PATH}/examples/server/public_simplechat"

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -11,7 +11,9 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-cmake-ggml.patch
+        fix-3rdparty.patch
 )
+file(REMOVE "${SOURCE_PATH}/common/json.hpp") # use nlohmann-json
 
 vcpkg_find_acquire_program(GIT)
 message(STATUS "Using git: ${GIT}")

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -19,12 +19,22 @@
       "host": true
     }
   ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    }
+  ],
   "features": {
     "cuda": {
       "description": "Use CUDA",
       "dependencies": [
         "cudnn"
       ]
+    },
+    "metal": {
+      "description": "Use Metal",
+      "supports": "osx | ios"
     },
     "opencl": {
       "description": "Use OpenCL",
@@ -42,7 +52,13 @@
       "description": "Build llama server",
       "supports": "windows | linux | osx",
       "dependencies": [
-        "curl"
+        {
+          "name": "curl",
+          "features": [
+            "ssl"
+          ]
+        },
+        "openssl"
       ]
     },
     "vulkan": {

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -44,6 +44,13 @@
     "vulkan": {
       "description": "Use Vulkan",
       "dependencies": [
+        {
+          "name": "glslang",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        },
         "vulkan"
       ]
     }

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/ggerganov/llama.cpp",
   "license": "MIT",
   "dependencies": [
+    "curl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -5,7 +5,11 @@
   "homepage": "https://github.com/ggerganov/llama.cpp",
   "license": "MIT",
   "dependencies": [
-    "curl",
+    {
+      "name": "curl",
+      "default-features": false
+    },
+    "nlohmann-json",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -1,14 +1,10 @@
 {
   "name": "llama-cpp",
-  "version-string": "b1695",
-  "description": "Port of Facebook's LLaMA model in C/C++",
+  "version": "4644",
+  "description": "LLM inference in C/C++",
   "homepage": "https://github.com/ggerganov/llama.cpp",
-  "supports": "windows | linux | osx",
+  "license": "MIT",
   "dependencies": [
-    {
-      "name": "openblas",
-      "platform": "windows"
-    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -19,33 +15,36 @@
     }
   ],
   "features": {
-    "clblast": {
-      "description": "Use CLBlast",
-      "dependencies": [
-        "clblast"
-      ]
-    },
-    "cublas": {
+    "cuda": {
       "description": "Use CUDA",
       "dependencies": [
         "cudnn"
       ]
     },
-    "mpi": {
-      "description": "Use MPI",
+    "opencl": {
+      "description": "Use OpenCL",
       "dependencies": [
-        {
-          "name": "msmpi",
-          "platform": "windows"
-        },
-        {
-          "name": "openmpi",
-          "platform": "!windows"
-        }
+        "opencl"
       ]
     },
-    "test": {
-      "description": "Build tests"
+    "openmp": {
+      "description": "Use OpenMP",
+      "dependencies": [
+        "openmp"
+      ]
+    },
+    "server": {
+      "description": "Build llama server",
+      "supports": "windows | linux | osx",
+      "dependencies": [
+        "curl"
+      ]
+    },
+    "vulkan": {
+      "description": "Use Vulkan",
+      "dependencies": [
+        "vulkan"
+      ]
     }
   }
 }

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -20,7 +20,7 @@
         {
           "name": "llama-cpp",
           "features": [
-            "cublas"
+            "cuda"
           ]
         },
         "nvidia-cnmem",
@@ -45,6 +45,12 @@
         },
         "liblzma",
         {
+          "name": "llama-cpp",
+          "features": [
+            "opencl"
+          ]
+        },
+        {
           "name": "onnx",
           "features": [
             "disable-static-registration",
@@ -62,6 +68,12 @@
       "supports": "x64 & windows",
       "dependencies": [
         "glslang",
+        {
+          "name": "llama-cpp",
+          "features": [
+            "vulkan"
+          ]
+        },
         "smol-v",
         "vulkan",
         "vulkan-headers"

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -32,13 +32,7 @@
       "name": "libdispatch",
       "platform": "windows | android"
     },
-    {
-      "name": "llama-cpp",
-      "features": [
-        "test"
-      ],
-      "platform": "windows | osx | linux"
-    },
+    "llama-cpp",
     {
       "name": "metal-cpp",
       "platform": "osx | ios"

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -32,7 +32,12 @@
       "name": "libdispatch",
       "platform": "windows | android"
     },
-    "llama-cpp",
+    {
+      "name": "llama-cpp",
+      "features": [
+        "server"
+      ]
+    },
     {
       "name": "metal-cpp",
       "platform": "osx | ios"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -93,7 +93,7 @@
       "port-version": 0
     },
     "llama-cpp": {
-      "baseline": "b1695",
+      "baseline": "4644",
       "port-version": 0
     },
     "metal-cpp": {

--- a/versions/l-/llama-cpp.json
+++ b/versions/l-/llama-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "919ca30bfaace2e8081098eb6e87ce39f060e290",
+      "version": "4644",
+      "port-version": 0
+    },
+    {
       "git-tree": "e740088bddef250c1962485745b0bc6cb45c33d0",
       "version-string": "b1695",
       "port-version": 0

--- a/versions/l-/llama-cpp.json
+++ b/versions/l-/llama-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "919ca30bfaace2e8081098eb6e87ce39f060e290",
+      "git-tree": "0012ab010bbdfe4574d65aab2555f5faf5cc1e4a",
       "version": "4644",
       "port-version": 0
     },


### PR DESCRIPTION
### Changes

Update to more later version. Support more features with OpenCL, Vulkan, and CUDA

### References

* https://github.com/ggerganov/llama.cpp/releases/tag/b4644
* #148 

### Triplet Support

* [x] `x64-windows`
* [x] `arm64-windows`: Requires Clang
* [x] `arm64-ios`
* [x] `arm64-osx`
* [x] `x64-osx`