### PR TITLE
[spine-runtimes] Create a new port with 4.2 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           sudo apt install -y pkg-config nasm \
             libnuma-dev libopenmpi-dev \
             libx11-dev libxi-dev libxext-dev libx11-xcb-dev \
-            xinerama xcursor xorg libglu1-mesa
+            libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa
 
       - name: "Run homebrew"
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,10 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           # sudo apt update -y
-          sudo apt install -y nasm libnuma-dev libopenmpi-dev libx11-dev libxi-dev libxext-dev libx11-xcb-dev
+          sudo apt install -y pkg-config nasm \
+            libnuma-dev libopenmpi-dev \
+            libx11-dev libxi-dev libxext-dev libx11-xcb-dev \
+            xinerama xcursor xorg libglu1-mesa
 
       - name: "Run homebrew"
         if: runner.os == 'macOS'

--- a/ports/spine-runtimes/CMakeLists.txt
+++ b/ports/spine-runtimes/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+project(spine-vcpkg-build C CXX)
+include(GNUInstallDirs)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
+if(MSVC)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
+add_subdirectory(spine-cpp)
+add_subdirectory(spine-c)
+if(BUILD_GLFW)
+    add_subdirectory(spine-glfw)
+endif()
+if(BUILD_SDL)
+    add_subdirectory(spine-sdl)
+endif()

--- a/ports/spine-runtimes/fix-cmake.patch
+++ b/ports/spine-runtimes/fix-cmake.patch
@@ -1,0 +1,178 @@
+diff --git a/spine-c/CMakeLists.txt b/spine-c/CMakeLists.txt
+index b7e4d2a..1862c17 100644
+--- a/spine-c/CMakeLists.txt
++++ b/spine-c/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.10)
+ project(spine-c)
+ 
+-include(${CMAKE_CURRENT_LIST_DIR}/../flags.cmake)
++# include(${CMAKE_CURRENT_LIST_DIR}/../flags.cmake)
+ 
+ include_directories(include)
+ file(GLOB INCLUDES "spine-c/include/**/*.h")
+@@ -10,5 +10,5 @@ file(GLOB SOURCES "spine-c/src/**/*.c")
+ add_library(spine-c STATIC ${SOURCES} ${INCLUDES})
+ target_include_directories(spine-c PUBLIC spine-c/include)
+ 
+-install(TARGETS spine-c DESTINATION dist/lib)
+-install(FILES ${INCLUDES} DESTINATION dist/include)
+\ No newline at end of file
++install(TARGETS spine-c DESTINATION lib)
++install(FILES ${INCLUDES} DESTINATION include/spine-c/spine)
+\ No newline at end of file
+diff --git a/spine-cpp/CMakeLists.txt b/spine-cpp/CMakeLists.txt
+index 9829b42..0669684 100644
+--- a/spine-cpp/CMakeLists.txt
++++ b/spine-cpp/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.10)
+ project(spine-cpp)
+ 
+-include(${CMAKE_CURRENT_LIST_DIR}/../flags.cmake)
++# include(${CMAKE_CURRENT_LIST_DIR}/../flags.cmake)
+ 
+ include_directories(include)
+ file(GLOB INCLUDES "spine-cpp/include/**/*.h")
+@@ -14,8 +14,9 @@ add_library(spine-cpp-lite STATIC ${SOURCES} ${INCLUDES} spine-cpp-lite/spine-cp
+ target_include_directories(spine-cpp-lite PUBLIC spine-cpp/include spine-cpp-lite)
+ 
+ # Install target
+-install(TARGETS spine-cpp EXPORT spine-cpp_TARGETS DESTINATION dist/lib)
+-install(FILES ${INCLUDES} DESTINATION dist/include)
++install(TARGETS spine-cpp EXPORT spine-cpp_TARGETS DESTINATION lib)
++install(FILES ${INCLUDES} DESTINATION include/spine)
++install(FILES spine-cpp-lite/spine-cpp-lite.h DESTINATION include)
+ 
+ # Export target
+ export(
+diff --git a/spine-glfw/CMakeLists.txt b/spine-glfw/CMakeLists.txt
+index 9f1a99c..0555ea4 100644
+--- a/spine-glfw/CMakeLists.txt
++++ b/spine-glfw/CMakeLists.txt
+@@ -3,48 +3,34 @@ project(spine-glfw)
+ 
+ include(FetchContent)
+ # Fetch GLFW
+-FetchContent_Declare(
+-        glfw
+-        GIT_REPOSITORY https://github.com/glfw/glfw.git
+-        GIT_TAG latest
+-        GIT_SHALLOW 1
+-)
+-FetchContent_MakeAvailable(glfw)
+-set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL " " FORCE)
+-set(GLFW_BUILD_TESTS OFF CACHE BOOL " " FORCE)
+-set(GLFW_BUILD_DOCS OFF CACHE BOOL " " FORCE)
+-set(GLFW_INSTALL OFF CACHE BOOL " " FORCE)
++find_package(glfw3 CONFIG REQUIRED) # glfw
+ 
+ # Fetch glbinding
+-FetchContent_Declare(
+-        glbinding
+-        GIT_REPOSITORY https://github.com/cginternals/glbinding.git
+-        GIT_TAG v3.3.0
+-        GIT_SHALLOW 1
+-)
+-FetchContent_MakeAvailable(glbinding)
+-set(OPTION_BUILD_DOCS OFF CACHE BOOL " " FORCE)
+-set(OPTION_BUILD_EXAMPLES OFF CACHE BOOL " " FORCE)
+-set(OPTION_BUILD_TEST OFF CACHE BOOL " " FORCE)
+-set(OPTION_BUILD_TOOLS OFF CACHE BOOL " " FORCE)
++find_package(glbinding CONFIG REQUIRED) # glbinding::glbinding glbinding::glbinding-aux
+ 
+ include_directories(${glbinding_SOURCE_DIR}/include)
+ include_directories(src)
+ 
++find_path(STB_INCLUDE_DIR NAMES stb_image.h REQUIRED)
++include_directories(${STB_INCLUDE_DIR})
++
+ # Find local OpenGL lib
+ find_package(OpenGL REQUIRED)
+ 
+ # Default flags
+-include(${CMAKE_SOURCE_DIR}/../flags.cmake)
++# include(${CMAKE_SOURCE_DIR}/../flags.cmake)
+ 
+ # Add spine-cpp
+-add_subdirectory(${CMAKE_SOURCE_DIR}/../spine-cpp ${CMAKE_BINARY_DIR}/spine-cpp-build)
++# add_subdirectory(${CMAKE_SOURCE_DIR}/../spine-cpp ${CMAKE_BINARY_DIR}/spine-cpp-build)
+ 
+ # spine-glfw library
+-add_library(spine-glfw STATIC src/spine-glfw.cpp src/spine-glfw.h src/stb_image.h)
++add_library(spine-glfw STATIC src/spine-glfw.cpp src/spine-glfw.h)
+ target_link_libraries(spine-glfw PRIVATE glbinding::glbinding)
+ target_link_libraries(spine-glfw LINK_PUBLIC spine-cpp-lite)
+ 
++install(TARGETS spine-glfw DESTINATION lib)
++install(FILES src/spine-glfw.h DESTINATION include)
++return()
+ # Example
+ add_executable(spine-glfw-example example/main.cpp)
+ target_link_libraries(spine-glfw-example PRIVATE glfw)
+diff --git a/spine-sdl/CMakeLists.txt b/spine-sdl/CMakeLists.txt
+index ad1cba9..d18ae73 100644
+--- a/spine-sdl/CMakeLists.txt
++++ b/spine-sdl/CMakeLists.txt
+@@ -2,43 +2,35 @@ cmake_minimum_required(VERSION 3.10)
+ project(spine-sdl)
+ 
+ # Default flags
+-include(${CMAKE_SOURCE_DIR}/../flags.cmake)
++# include(${CMAKE_SOURCE_DIR}/../flags.cmake)
+ 
+ # Add spine-cpp and spine-c
+-add_subdirectory(${CMAKE_SOURCE_DIR}/../spine-cpp ${CMAKE_BINARY_DIR}/spine-cpp-build)
+-add_subdirectory(${CMAKE_SOURCE_DIR}/../spine-c ${CMAKE_BINARY_DIR}/spine-c)
++# add_subdirectory(${CMAKE_SOURCE_DIR}/../spine-cpp ${CMAKE_BINARY_DIR}/spine-cpp-build)
++# add_subdirectory(${CMAKE_SOURCE_DIR}/../spine-c ${CMAKE_BINARY_DIR}/spine-c)
+ 
+ # SDL
+-include(FetchContent)
+-FetchContent_Declare(SDL GIT_REPOSITORY https://github.com/libsdl-org/SDL GIT_TAG release-2.30.2)
+-set(FETCHCONTENT_QUIET NO)
+-set(SDL_SHARED OFF)
+-set(SDL_STATIC ON)
+-set(SDL_TEST OFF)
+-set(SDL_EXAMPLES OFF)
+-set(SDL_INSTALL OFF)
+-set(SDL_TESTS OFF)
+-set(SDL_TESTS_BUILD OFF)
+-set(SDL_TESTS_BUILD_C OFF)
+-set(SDL_TESTS_BUILD_CPP OFF)
+-set(SDL_TESTS_BUILD_JOYSTICK OFF)
+-set(SDL_TESTS_BUILD_RENDERER OFF)
+-FetchContent_MakeAvailable(SDL)
++find_package(SDL2 CONFIG REQUIRED)
++if((NOT TARGET SDL2::SDL2) AND (TARGET SDL2::SDL2-static))
++	add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
++endif()
+ 
+ include_directories(src)
++find_path(STB_INCLUDE_DIR NAMES stb_image.h REQUIRED)
++include_directories(${STB_INCLUDE_DIR})
+ 
+ # spine-sdl-c library
+-add_library(spine-sdl-c STATIC src/spine-sdl-c.c src/spine-sdl-c.h src/stb_image.h)
+-target_link_libraries(spine-sdl-c LINK_PUBLIC SDL2-static spine-c)
+-install(TARGETS spine-sdl-c DESTINATION dist/lib)
+-install(FILES src/spine-sdl-c.h src/stb_image.h DESTINATION dist/include)
++add_library(spine-sdl-c STATIC src/spine-sdl-c.c src/spine-sdl-c.h)
++target_link_libraries(spine-sdl-c LINK_PUBLIC SDL2::SDL2 spine-c)
++install(TARGETS spine-sdl-c DESTINATION lib)
++install(FILES src/spine-sdl-c.h DESTINATION include/spine-c)
+ 
+ # spine-sdl-cpp library
+-add_library(spine-sdl-cpp STATIC src/spine-sdl-cpp.cpp src/spine-sdl-cpp.h src/stb_image.h)
+-target_link_libraries(spine-sdl-cpp LINK_PUBLIC SDL2-static spine-cpp)
+-install(TARGETS spine-sdl-cpp DESTINATION dist/lib)
+-install(FILES src/spine-sdl-cpp.h src/stb_image.h DESTINATION dist/include)
++add_library(spine-sdl-cpp STATIC src/spine-sdl-cpp.cpp src/spine-sdl-cpp.h)
++target_link_libraries(spine-sdl-cpp LINK_PUBLIC SDL2::SDL2 spine-cpp)
++install(TARGETS spine-sdl-cpp DESTINATION lib)
++install(FILES src/spine-sdl-cpp.h DESTINATION include)
+ 
++return()
+ # Example (spine-sdl-c)
+ add_executable(spine-sdl-c-example example/main.c)
+ target_link_libraries(spine-sdl-c-example SDL2-static spine-sdl-c)

--- a/ports/spine-runtimes/portfile.cmake
+++ b/ports/spine-runtimes/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY) # the project doesn't support SHARED
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO EsotericSoftware/spine-runtimes
+    REF 1cdbf9be1a92e0a3015af8e0f0e1b05b872e33c9
+    SHA512 444c8409c25e92b6c02a4d05f3ec84fced9622b62fbe68a4c4ce813b1451da5188b08be6df37dacde7da7a0bd01cb7d476afc531574793871b850025ec3c505a
+    HEAD_REF 4.2
+    PATCHES
+        fix-cmake.patch
+)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/spine-glfw/src/stb_image.h"
+    "${SOURCE_PATH}/spine-sdl/src/stb_image.h"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        glfw    BUILD_GLFW
+        sdl2    BUILD_SDL
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/bin"
+    "${CURRENT_PACKAGES_DIR}/bin"
+)
+
+# https://github.com/EsotericSoftware/spine-runtimes?tab=License-1-ov-file
+# Copyright (c) 2013-2023, Esoteric Software LLC
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/spine-runtimes/vcpkg.json
+++ b/ports/spine-runtimes/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "spine-runtimes",
+  "version": "2025-02-11",
+  "description": "2D skeletal animation runtimes for Spine",
+  "homepage": "https://github.com/EsotericSoftware/spine-runtimes",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "glfw": {
+      "description": "Build spine-glfw",
+      "dependencies": [
+        "glbinding",
+        "glfw3",
+        "stb"
+      ]
+    },
+    "sdl2": {
+      "description": "Build spine-sdl",
+      "dependencies": [
+        "sdl2",
+        "stb"
+      ]
+    }
+  }
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -74,9 +74,15 @@
     {
       "name": "spine-runtimes",
       "features": [
-        "glfw",
         "sdl2"
       ]
+    },
+    {
+      "name": "spine-runtimes",
+      "features": [
+        "glfw"
+      ],
+      "platform": "native"
     },
     {
       "name": "sse2neon",

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2025-02-09",
+  "version-date": "2025-02-14",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows | linux | osx | ios",
@@ -70,6 +70,13 @@
         "tools"
       ],
       "platform": "windows"
+    },
+    {
+      "name": "spine-runtimes",
+      "features": [
+        "glfw",
+        "sdl2"
+      ]
     },
     {
       "name": "sse2neon",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -204,6 +204,10 @@
       "baseline": "2024-09-26",
       "port-version": 0
     },
+    "spine-runtimes": {
+      "baseline": "2025-02-11",
+      "port-version": 0
+    },
     "sse2neon": {
       "baseline": "2024-08-17",
       "port-version": 0

--- a/versions/s-/spine-runtimes.json
+++ b/versions/s-/spine-runtimes.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2c37ad373b4a7a591258f61bc3bb0c3c70c1c27f",
+      "version": "2025-02-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create a new port `spine-runtimes` with 4.2 branch. Visited 2025-02-14

### References

* Resolve #319 
* https://github.com/microsoft/vcpkg/pull/27006
* https://github.com/EsotericSoftware/spine-runtimes/tree/4.2

### Triplet Support

* `x64-windows`
* `arm64-windows`
