### PR TITLE
[godot] Support tool build and installation with 4.3-stable version

### DIFF
--- a/ports/godot/portfile.cmake
+++ b/ports/godot/portfile.cmake
@@ -1,9 +1,23 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+# set(VCPKG_POLICY_ALLOW_EXES_IN_BIN enabled)
+# set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+
+# https://www.reddit.com/r/godot/comments/1gw220q/latest_visual_studio_update_1712_broke_scons/
+# https://github.com/godotengine/godot issue 95861
+vcpkg_download_distfile(GODOT_PR_96167_PATCH
+    URLS "https://github.com/godotengine/godot/pull/96167.diff?full_index=1"
+    FILENAME "godot-fix-pr-96167.patch"
+    SHA512 c0438cd49b0d7f2a39b95f4064e89ccea79e6ff4a9d5b3291af5f1c11f5bd4935b8b4b99c332947ad65e1d3f172adc03979717b74db0ea389da692b494fd8061
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO godotengine/godot
     REF "${VERSION}-stable"
     SHA512 ce20235f1a5f8a5dc22f4bec6c4b5ab7c66aa3b35733f9fc26f905e564c4671df370c68db1ea65b205e00f29863d6d6f5ea6878996a4d69d32f728ecc91c8726
     HEAD_REF 4.3
+    PATCHES
+        "${GODOT_PR_96167_PATCH}"
 )
 
 # https://scons.org/
@@ -12,17 +26,6 @@ x_vcpkg_get_python_packages(
     PACKAGES SCons
     OUT_PYTHON_VAR PYTHON3
 )
-
-function(get_python_version PYTHON OUT_VERSION)
-    execute_process(
-        COMMAND "${PYTHON}" --version
-        OUTPUT_VARIABLE output OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    string(REGEX MATCH "([0-9]+\\.[0-9]+\\.[0-9]+)" output "${output}")
-    set(${OUT_VERSION} "${output}" PARENT_SCOPE)
-endfunction()
-get_python_version("${PYTHON3}" PYTHON_VERSION)
-message(STATUS "Using python3: ${PYTHON3} ${PYTHON_VERSION}")
 
 function(get_python_site_packages PYTHON OUT_PATH)
     execute_process(
@@ -37,38 +40,53 @@ message(STATUS "Using site-packages: ${SITE_PACKAGES_DIR}")
 find_program(SCONS NAMES scons PATHS "${SITE_PACKAGES_DIR}/Scripts" NO_DEFAULT_PATH REQUIRED)
 message(STATUS "Using scons: ${SCONS}")
 
+function(scons_msvc_build)
+    cmake_parse_arguments(PARSE_ARGV 0 arg "TESTS;DEBUG_SYMBOLS" "TARGET;DIRECTORY" "SCONS_FLAGS")
+    if(NOT arg_DIRECTORY)
+        set(arg_DIRECTORY "${SOURCE_PATH}")
+    endif()
+    set(TEST_OPT "tests=false")
+    if(arg_TESTS)
+        set(TEST_OPT "tests=true")
+    endif()
+    set(DEBUG_SYMBOLS_OPT "debug_symbols=no")
+    if(arg_DEBUG_SYMBOLS)
+        set(DEBUG_SYMBOLS_OPT "debug_symbols=yes")
+    endif()
+    vcpkg_execute_required_process(
+        COMMAND "${SCONS}" platform=windows vsproj=yes vsproj_gen_only=no
+            target=${arg_TARGET} ${arg_SCONS_FLAGS} ${TEST_OPT} ${DEBUG_SYMBOLS_OPT}
+        LOGNAME "build-${arg_TARGET}"
+        WORKING_DIRECTORY "${arg_DIRECTORY}"
+    )
+endfunction()
+
 # https://scons.org/doc/latest/HTML/scons-user/index.html
-# https://github.com/godotengine/godot/blob/4.3-stable/.github/workflows/runner.yml
 set(ENV{SCONS_CACHE} "${CURRENT_BUILDTREES_DIR}/scons-cache")
 set(ENV{SCONSFLAGS} "--jobs=${VCPKG_CONCURRENCY}")
-if(VCPKG_TARGET_IS_WINDOWS)
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-        set(ARCH_OPT "arch=x86_64")
-    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        set(ARCH_OPT "arch=arm64")
-    endif()
+
+# https://github.com/godotengine/godot/blob/4.3-stable/.github/workflows/runner.yml
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(ARCH_OPT "arch=x86_64")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(ARCH_OPT "arch=arm64")
 endif()
 
-# scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=false ${{ env.SCONSFLAGS }}
+if(VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Building target=template_release")
+    scons_msvc_build(TARGET template_release
+        SCONS_FLAGS "${ARCH_OPT}"
+    )
+    message(STATUS "Building target=editor")
+    scons_msvc_build(TARGET editor
+        SCONS_FLAGS "${ARCH_OPT}" windows_subsystem=console
+    )
+    file(GLOB EXE_FILES "${SOURCE_PATH}/bin/*.exe")
+    file(INSTALL ${EXE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+endif()
 
-message(STATUS "Building target=template_release")
-vcpkg_execute_required_process(
-    COMMAND "${SCONS}" ${ARCH_OPT} --ignore-errors # --enable-virtualenv
-        platform=windows target=template_release
-        tests=false
-        debug_symbols=no vsproj=yes vsproj_gen_only=no
-    LOGNAME target-template
-    WORKING_DIRECTORY "${SOURCE_PATH}"
+file(INSTALL "${SOURCE_PATH}/README.md" "${SOURCE_PATH}/CHANGELOG.md" "${SOURCE_PATH}/AUTHORS.md"
+             "${SOURCE_PATH}/LOGO_LICENSE.txt" "${SOURCE_PATH}/logo.png" "${SOURCE_PATH}/icon.png"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
-
-message(STATUS "Building target=editor")
-vcpkg_execute_required_process(
-    COMMAND "${SCONS}" ${ARCH_OPT} --ignore-errors
-        platform=windows target=editor
-        tests=false
-        debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
-    LOGNAME target-editor
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-)
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/godot/portfile.cmake
+++ b/ports/godot/portfile.cmake
@@ -1,0 +1,74 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO godotengine/godot
+    REF "${VERSION}-stable"
+    SHA512 ce20235f1a5f8a5dc22f4bec6c4b5ab7c66aa3b35733f9fc26f905e564c4671df370c68db1ea65b205e00f29863d6d6f5ea6878996a4d69d32f728ecc91c8726
+    HEAD_REF 4.3
+)
+
+# https://scons.org/
+x_vcpkg_get_python_packages(
+    PYTHON_VERSION 3
+    PACKAGES SCons
+    OUT_PYTHON_VAR PYTHON3
+)
+
+function(get_python_version PYTHON OUT_VERSION)
+    execute_process(
+        COMMAND "${PYTHON}" --version
+        OUTPUT_VARIABLE output OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "([0-9]+\\.[0-9]+\\.[0-9]+)" output "${output}")
+    set(${OUT_VERSION} "${output}" PARENT_SCOPE)
+endfunction()
+get_python_version("${PYTHON3}" PYTHON_VERSION)
+message(STATUS "Using python3: ${PYTHON3} ${PYTHON_VERSION}")
+
+function(get_python_site_packages PYTHON OUT_PATH)
+    execute_process(
+        COMMAND "${PYTHON}" -c "import site; print(site.getsitepackages()[0])"
+        OUTPUT_VARIABLE output OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(${OUT_PATH} "${output}" PARENT_SCOPE)
+endfunction()
+get_python_site_packages("${PYTHON3}" SITE_PACKAGES_DIR)
+message(STATUS "Using site-packages: ${SITE_PACKAGES_DIR}")
+
+find_program(SCONS NAMES scons PATHS "${SITE_PACKAGES_DIR}/Scripts" NO_DEFAULT_PATH REQUIRED)
+message(STATUS "Using scons: ${SCONS}")
+
+# https://scons.org/doc/latest/HTML/scons-user/index.html
+# https://github.com/godotengine/godot/blob/4.3-stable/.github/workflows/runner.yml
+set(ENV{SCONS_CACHE} "${CURRENT_BUILDTREES_DIR}/scons-cache")
+set(ENV{SCONSFLAGS} "--jobs=${VCPKG_CONCURRENCY}")
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(ARCH_OPT "arch=x86_64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(ARCH_OPT "arch=arm64")
+    endif()
+endif()
+
+# scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=false ${{ env.SCONSFLAGS }}
+
+message(STATUS "Building target=template_release")
+vcpkg_execute_required_process(
+    COMMAND "${SCONS}" ${ARCH_OPT} --ignore-errors # --enable-virtualenv
+        platform=windows target=template_release
+        tests=false
+        debug_symbols=no vsproj=yes vsproj_gen_only=no
+    LOGNAME target-template
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+)
+
+message(STATUS "Building target=editor")
+vcpkg_execute_required_process(
+    COMMAND "${SCONS}" ${ARCH_OPT} --ignore-errors
+        platform=windows target=editor
+        tests=false
+        debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
+    LOGNAME target-editor
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/godot/portfile.cmake
+++ b/ports/godot/portfile.cmake
@@ -45,12 +45,10 @@ function(scons_build)
     if(NOT arg_DIRECTORY)
         set(arg_DIRECTORY "${SOURCE_PATH}")
     endif()
-    set(TEST_OPT "tests=false")
-    set(DEBUG_SYMBOLS_OPT "debug_symbols=no")
     message(STATUS "Building target ${arg_TARGET}")
     vcpkg_execute_required_process(
-        COMMAND "${SCONS}"
-            target=${arg_TARGET} ${arg_SCONS_FLAGS} ${TEST_OPT} ${DEBUG_SYMBOLS_OPT}
+        COMMAND "${SCONS}" target=${arg_TARGET} ${arg_SCONS_FLAGS}
+            tests=false deprecated=no debug_symbols=no
         LOGNAME "build-${arg_TARGET}"
         WORKING_DIRECTORY "${arg_DIRECTORY}"
     )
@@ -68,7 +66,7 @@ elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
 endif()
 
 # ${SOURCE_PATH}/.github/workflows
-# todo: linux, android, ios, web
+# todo: android, ios, web
 if(VCPKG_TARGET_IS_WINDOWS) # windows_build.yml
     scons_build(TARGET template_release
         SCONS_FLAGS platform=windows arch=${ARCH_NAME} vsproj=yes vsproj_gen_only=no
@@ -76,8 +74,11 @@ if(VCPKG_TARGET_IS_WINDOWS) # windows_build.yml
     scons_build(TARGET editor
         SCONS_FLAGS platform=windows arch=${ARCH_NAME} vsproj=yes vsproj_gen_only=no windows_subsystem=console
     )
-    file(GLOB EXE_FILES "${SOURCE_PATH}/bin/*.exe")
-    file(INSTALL ${EXE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    vcpkg_copy_tools(
+        TOOL_NAMES  godot.windows.template_release.${ARCH_NAME}
+                    godot.windows.editor.${ARCH_NAME}
+        SEARCH_DIR "${SOURCE_PATH}/bin" AUTO_CLEAN
+    )
 
 elseif(VCPKG_TARGET_IS_OSX) # macos_build.yml
     scons_build(TARGET template_release
@@ -87,7 +88,21 @@ elseif(VCPKG_TARGET_IS_OSX) # macos_build.yml
         SCONS_FLAGS platform=macos arch=${ARCH_NAME} optimize=size vulkan=false
     )
     vcpkg_copy_tools(
-        TOOL_NAMES godot.macos.template_release.${ARCH_NAME} godot.macos.editor.${ARCH_NAME}
+        TOOL_NAMES  godot.macos.template_release.${ARCH_NAME}
+                    godot.macos.editor.${ARCH_NAME}
+        SEARCH_DIR "${SOURCE_PATH}/bin" AUTO_CLEAN
+    )
+
+elseif(VCPKG_TARGET_IS_LINUX) # linux_build.yml
+    scons_build(TARGET template_release
+        SCONS_FLAGS platform=linuxbsd arch=${ARCH_NAME} optimize=size
+    )
+    scons_build(TARGET editor
+        SCONS_FLAGS platform=linuxbsd arch=${ARCH_NAME} optimize=size
+    )
+    vcpkg_copy_tools(
+        TOOL_NAMES  godot.linuxbsd.template_release.${ARCH_NAME}
+                    godot.linuxbsd.editor.${ARCH_NAME}
         SEARCH_DIR "${SOURCE_PATH}/bin" AUTO_CLEAN
     )
 

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "godot",
+  "version": "4.3",
+  "description": "Godot Engine – Multi-platform 2D and 3D game engine",
+  "homepage": "https://godotengine.org/",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    }
+  ]
+}

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Godot Engine - Multi-platform 2D and 3D game engine",
   "homepage": "https://godotengine.org/",
   "license": "MIT",
-  "supports": "windows | osx",
+  "supports": "windows | osx | linux",
   "dependencies": [
     {
       "name": "vcpkg-get-python-packages",

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "godot",
   "version": "4.3",
-  "description": "Godot Engine – Multi-platform 2D and 3D game engine",
+  "description": "Godot Engine - Multi-platform 2D and 3D game engine",
   "homepage": "https://godotengine.org/",
   "license": "MIT",
-  "supports": "windows",
+  "supports": "windows | osx",
   "dependencies": [
     {
       "name": "vcpkg-get-python-packages",

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -37,6 +37,10 @@
       "description": "Default ports to test",
       "dependencies": [
         {
+          "name": "godot",
+          "platform": "x64 & windows"
+        },
+        {
           "name": "d3d12-transition-layer",
           "features": [
             "pix"

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -29,7 +29,7 @@
     "glslang",
     {
       "name": "godot",
-      "platform": "osx"
+      "platform": "osx | linux"
     },
     {
       "name": "libdispatch",

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -28,6 +28,10 @@
     },
     "glslang",
     {
+      "name": "godot",
+      "platform": "osx"
+    },
+    {
       "name": "libdispatch",
       "platform": "windows | android"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -72,6 +72,10 @@
       "baseline": "15.0.0",
       "port-version": 0
     },
+    "godot": {
+      "baseline": "4.3",
+      "port-version": 0
+    },
     "google-filament": {
       "baseline": "1.40.0",
       "port-version": 0

--- a/versions/g-/godot.json
+++ b/versions/g-/godot.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "07fc797178d9e6c4519c058901bd4f445bf877ad",
+      "version": "4.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Rework based on scripts of several years ago...

Use [SCons](https://github.com/SCons/scons/wiki) to build the Godot Engine's executables

https://github.com/godotengine/godot/blob/77dcf97d82cbfe4e4615475fa52ca03da645dbd8/SConstruct#L198

> [!CAUTION]
> The port is NOT a library port.  
> For the library, check https://github.com/microsoft/vcpkg/tree/master/ports/godot-cpp

### References

* Resolve #322 
* https://github.com/godotengine/godot/releases/tag/4.3-stable
* https://github.com/microsoft/vcpkg/tree/master/ports/godot-cpp

### Triplet Support

* `x64-windows`
