### PR TITLE
[godot] Support "spine-runtimes" feature with custom module build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           # sudo apt update -y
-          sudo apt install -y pkg-config nasm \
-            libnuma-dev libopenmpi-dev \
-            libx11-dev libxi-dev libxext-dev libx11-xcb-dev \
-            libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa
+          sudo apt install -y $(cat test/packages-apt.txt)
 
       - name: "Run homebrew"
         if: runner.os == 'macOS'
@@ -111,6 +108,57 @@ jobs:
           VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
           VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
           VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
+
+  host-tools:
+    name: "Host Tools"
+    runs-on: ${{ matrix.runner_image }} # https://github.com/actions/runner-images
+    strategy:
+      matrix:
+        include:
+          - runner_image: "ubuntu-latest"
+          - runner_image: "macos-latest"
+          # - runner_image: "windows-latest"
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
+          vcpkgGitCommitId: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13
+          runVcpkgInstall: false
+
+      - name: "Run apt"
+        if: runner.os == 'Linux'
+        run: |
+          # sudo apt update -y
+          sudo apt install -y $(cat test/packages-apt.txt)
+
+      - name: "Run homebrew"
+        if: runner.os == 'macOS'
+        run: brew install autoconf automake libtool
+
+      - uses: microsoft/setup-msbuild@v2
+        if: runner.os == 'Windows'
+        with:
+          msbuild-architecture: x64
+
+      - uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
+          vcpkgGitCommitId: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13
+          runVcpkgInstall: true
+          runVcpkgFormatString: '[`install`, `--x-feature`, `host-tools`, `--clean-after-build`]'
+          vcpkgJsonGlob: "test/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "test/vcpkg-configuration.json"
+        env:
+          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
+          VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
+          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
 
   android:
     name: "Android"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         include:
           - runner_image: "ubuntu-latest"
-          - runner_image: "macos-latest"
+          - runner_image: "macos-13"
           # - runner_image: "windows-latest"
       fail-fast: false
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
         shell: pwsh
 
-      - name: "Run vcpkg(${{matrix.triplet}})"
+      - name: "Run vcpkg(${{ matrix.triplet }})"
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           vcpkg install --keep-going \
@@ -95,9 +95,9 @@ jobs:
           VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
           VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
           VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
-          VCPKG_DEFAULT_TRIPLET: "${{matrix.triplet}}"
+          VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
 
-      - name: "Run vcpkg(${{matrix.triplet}})"
+      - name: "Run vcpkg(${{ matrix.triplet }})"
         if: runner.os == 'Windows'
         run: |
           vcpkg install --keep-going `
@@ -110,7 +110,7 @@ jobs:
           VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
           VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
           VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
-          VCPKG_DEFAULT_TRIPLET: "${{matrix.triplet}}"
+          VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
 
   android:
     name: "Android"

--- a/ports/godot/portfile.cmake
+++ b/ports/godot/portfile.cmake
@@ -118,6 +118,11 @@ else()
     message(FATAL_ERROR "Unknown arch: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()
 
+vcpkg_find_acquire_program(PKGCONFIG)
+message(STATUS "Using pkgconfig: ${PKGCONFIG}")
+get_filename_component(PKGCONFIG_PATH "${PKGCONFIG}" PATH)
+vcpkg_add_to_path(PREPEND "${PKGCONFIG_PATH}")
+
 # ${SOURCE_PATH}/.github/workflows
 # todo: android, ios, web
 if(VCPKG_TARGET_IS_WINDOWS) # windows_build.yml

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -15,7 +15,6 @@
   "features": {
     "spine-runtimes": {
       "description": "https://esotericsoftware.com/spine-godot",
-      "supports": "windows | osx",
       "dependencies": [
         "spine-runtimes"
       ]

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "godot",
   "version": "4.3",
+  "port-version": 1,
   "description": "Godot Engine - Multi-platform 2D and 3D game engine",
   "homepage": "https://godotengine.org/",
   "license": "MIT",

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -15,6 +15,7 @@
   "features": {
     "spine-runtimes": {
       "description": "https://esotericsoftware.com/spine-godot",
+      "supports": "windows | osx",
       "dependencies": [
         "spine-runtimes"
       ]

--- a/ports/godot/vcpkg.json
+++ b/ports/godot/vcpkg.json
@@ -10,5 +10,13 @@
       "name": "vcpkg-get-python-packages",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "spine-runtimes": {
+      "description": "https://esotericsoftware.com/spine-godot",
+      "dependencies": [
+        "spine-runtimes"
+      ]
+    }
+  }
 }

--- a/test/packages-apt.txt
+++ b/test/packages-apt.txt
@@ -5,3 +5,10 @@ libx11-dev
 libxi-dev
 libxext-dev
 libx11-xcb-dev
+python3-pip
+python3-venv
+pkg-config
+libxinerama-dev
+libxcursor-dev
+xorg-dev
+libglu1-mesa

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -38,6 +38,9 @@
       "dependencies": [
         {
           "name": "godot",
+          "features": [
+            "spine-runtimes"
+          ],
           "platform": "x64 & windows"
         },
         {

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -1,113 +1,143 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "test",
-  "version-date": "2025-02-14",
+  "version-date": "2025-02-26",
   "description": "vcpkg registry maintained by @luncliff",
   "homepage": "https://github.com/luncliff/vcpkg-registry",
   "supports": "windows | linux | osx | ios",
   "dependencies": [
-    "abseil",
     {
-      "name": "coreml-tools",
-      "platform": "osx | ios"
+      "name": "vcpkg-cmake",
+      "host": true
     },
     {
-      "name": "cpuinfo",
-      "features": [
-        "tools"
-      ],
-      "platform": "linux"
-    },
-    {
-      "name": "d3d12-transition-layer",
-      "platform": "windows"
-    },
-    {
-      "name": "fbgemm",
-      "platform": "x64"
-    },
-    "glslang",
-    {
-      "name": "godot",
-      "platform": "osx | linux"
-    },
-    {
-      "name": "libdispatch",
-      "platform": "windows | android"
-    },
-    "llama-cpp",
-    {
-      "name": "llama-cpp",
-      "features": [
-        "server"
-      ],
-      "platform": "windows | linux | osx"
-    },
-    {
-      "name": "metal-cpp",
-      "platform": "osx | ios"
-    },
-    {
-      "name": "metal-cpp",
-      "platform": "osx | ios"
-    },
-    "miniaudio",
-    {
-      "name": "onnx",
-      "features": [
-        "disable-static-registration",
-        "test"
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    }
+  ],
+  "features": {
+    "host-tools": {
+      "description": "install tool ports, with host: true option",
+      "supports": "native",
+      "dependencies": [
+        {
+          "name": "godot",
+          "host": true,
+          "features": [
+            "spine-runtimes"
+          ],
+          "platform": "osx"
+        },
+        {
+          "name": "godot",
+          "host": true,
+          "platform": "linux"
+        }
       ]
     },
-    {
-      "name": "opencl",
-      "platform": "windows | linux"
-    },
-    {
-      "name": "opencl-on-dx12",
-      "platform": "windows"
-    },
-    "openssl3",
-    {
-      "name": "openssl3",
-      "features": [
-        "tools"
-      ],
-      "platform": "windows"
-    },
-    {
-      "name": "spine-runtimes",
-      "features": [
-        "sdl2"
+    "test": {
+      "description": "install library ports",
+      "dependencies": [
+        "abseil",
+        {
+          "name": "coreml-tools",
+          "platform": "osx | ios"
+        },
+        {
+          "name": "cpuinfo",
+          "features": [
+            "tools"
+          ],
+          "platform": "linux"
+        },
+        {
+          "name": "d3d12-transition-layer",
+          "platform": "windows"
+        },
+        {
+          "name": "fbgemm",
+          "platform": "x64"
+        },
+        "glslang",
+        {
+          "name": "libdispatch",
+          "platform": "windows | android"
+        },
+        "llama-cpp",
+        {
+          "name": "llama-cpp",
+          "features": [
+            "server"
+          ],
+          "platform": "windows | linux | osx"
+        },
+        {
+          "name": "metal-cpp",
+          "platform": "osx | ios"
+        },
+        {
+          "name": "metal-cpp",
+          "platform": "osx | ios"
+        },
+        "miniaudio",
+        {
+          "name": "onnx",
+          "features": [
+            "disable-static-registration",
+            "test"
+          ]
+        },
+        {
+          "name": "opencl",
+          "platform": "windows | linux"
+        },
+        {
+          "name": "opencl-on-dx12",
+          "platform": "windows"
+        },
+        "openssl3",
+        {
+          "name": "openssl3",
+          "features": [
+            "tools"
+          ],
+          "platform": "windows"
+        },
+        {
+          "name": "spine-runtimes",
+          "features": [
+            "sdl2"
+          ]
+        },
+        {
+          "name": "spine-runtimes",
+          "features": [
+            "glfw"
+          ],
+          "platform": "native"
+        },
+        {
+          "name": "sse2neon",
+          "platform": "x86"
+        },
+        {
+          "name": "tensorflow-lite",
+          "platform": "windows"
+        },
+        {
+          "name": "tensorflow-lite",
+          "features": [
+            "gpu"
+          ],
+          "platform": "windows & !arm"
+        },
+        "xatlas",
+        {
+          "name": "xnnpack",
+          "platform": "linux"
+        },
+        "zlib-ng"
       ]
-    },
-    {
-      "name": "spine-runtimes",
-      "features": [
-        "glfw"
-      ],
-      "platform": "native"
-    },
-    {
-      "name": "sse2neon",
-      "platform": "x86"
-    },
-    {
-      "name": "tensorflow-lite",
-      "platform": "windows"
-    },
-    {
-      "name": "tensorflow-lite",
-      "features": [
-        "gpu"
-      ],
-      "platform": "windows & !arm"
-    },
-    "xatlas",
-    {
-      "name": "xnnpack",
-      "platform": "linux"
-    },
-    "zlib-ng"
-  ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -74,7 +74,7 @@
     },
     "godot": {
       "baseline": "4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "google-filament": {
       "baseline": "1.40.0",

--- a/versions/g-/godot.json
+++ b/versions/g-/godot.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1f0d7b8d0d63a5f97a4ffd2d69d257d0f65bad8b",
+      "git-tree": "43065bcd713684c0ce19c22de66b1c878d1854d4",
       "version": "4.3",
       "port-version": 1
     },

--- a/versions/g-/godot.json
+++ b/versions/g-/godot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f0d7b8d0d63a5f97a4ffd2d69d257d0f65bad8b",
+      "version": "4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "07fc797178d9e6c4519c058901bd4f445bf877ad",
       "version": "4.3",
       "port-version": 0

--- a/versions/g-/godot.json
+++ b/versions/g-/godot.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "43065bcd713684c0ce19c22de66b1c878d1854d4",
+      "git-tree": "789d16507b72f8c6caf01e7d243c735980196b02",
       "version": "4.3",
       "port-version": 1
     },


### PR DESCRIPTION
### Changes

* Build sources of https://esotericsoftware.com/spine-godot with `spine-runtimes` port
* https://github.com/EsotericSoftware/spine-runtimes/tree/4.2/spine-godot

### References

* https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/custom_modules_in_cpp.html
* #324
* #320 

### Triplet Support

Currently, CCFLAGS customization causes build error. There is no support chage, but need to be cautious.

* `x64-windows`
* `x64-linux`
* `x64-osx`, `arm64-osx`
