### PR TITLE
[abseil] fix ABSL_CONSUME_DLL in installed header files

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -28,4 +28,12 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
 )
 
+if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic"))
+    message(WARNING "macro 'ABSL_CONSUME_DLL' may needed in the abseil-cpp importing sources")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/config.h"
+                         "defined(ABSL_CONSUME_DLL)" "1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h"
+                         "defined(ABSL_CONSUME_DLL)" "1")
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,11 +1,8 @@
 {
   "name": "abseil",
   "version": "20240722.0",
-  "description": [
-    "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
-    "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",
-    "Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole."
-  ],
+  "port-version": 1,
+  "description": "Abseil is an open-source collection of C++ code (compliant to C++17) designed to augment the C++ standard library",
   "homepage": "https://github.com/abseil/abseil-cpp",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c071be2d2b2bf21efbfa5f3127d020fb557c9ba",
+      "version": "20240722.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8b76b57b1d295b2fc05e9ed754af745f26ec4c02",
       "version": "20240722.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2,7 +2,7 @@
   "default": {
     "abseil": {
       "baseline": "20240722.0",
-      "port-version": 0
+      "port-version": 1
     },
     "apple-crypto": {
       "baseline": "3.0.0",


### PR DESCRIPTION
### Changes

* Warn and modifty `ABSL_CONSUME_DLL` in the portfile.cmake
* Simplify the port description

### References

* Reported in #328 
* #235 
