### PR TITLE
CI: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,20 +38,13 @@ jobs:
       matrix:
         include:
           - runner_image: "ubuntu-latest"
-            triplet: "x64-linux"
           - runner_image: "macos-13"
-            triplet: "x64-osx"
-          - runner_image: "macos-13"
-            triplet: "x64-ios-simulator"
-          - runner_image: "macos-13"
-            triplet: "arm64-osx"
-          - runner_image: "macos-13"
-            triplet: "arm64-ios"
           - runner_image: "windows-latest"
-            triplet: "x64-windows"
-          - runner_image: "windows-latest"
-            triplet: "arm64-windows"
       fail-fast: false
+    env:
+      VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
+      VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
+      VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: aws-actions/configure-aws-credentials@v4
@@ -93,40 +86,78 @@ jobs:
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
         shell: pwsh
 
-      - name: "Run vcpkg(${{ matrix.triplet }})"
-        if: runner.os == 'Linux' || runner.os == 'macOS'
+      - name: "Run vcpkg(x64-osx)"
+        if: runner.os == 'macOS'
         run: |
           vcpkg install --keep-going \
-            --clean-buildtrees-after-build \
-            --clean-packages-after-build \
+            --clean-buildtrees-after-build --clean-packages-after-build \
             --x-manifest-root test \
             --x-feature test
         shell: bash
         env:
-          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
-          VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
-          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
-          VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
+          VCPKG_DEFAULT_TRIPLET: "x64-osx"
 
-      - name: "Run vcpkg(${{ matrix.triplet }})"
+      - name: "Run vcpkg(arm64-ios)"
+        if: runner.os == 'macOS'
+        run: |
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
+        shell: bash
+        env:
+          VCPKG_DEFAULT_TRIPLET: "arm64-ios"
+
+      - name: "Run vcpkg(arm64-ios-simulator)"
+        if: runner.os == 'macOS'
+        run: |
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
+        shell: bash
+        env:
+          VCPKG_DEFAULT_TRIPLET: "arm64-ios-simulator"
+        continue-on-error: true
+
+      - name: "Run vcpkg(x64-linux)"
+        if: runner.os == 'Linux'
+        run: |
+          vcpkg install --keep-going \
+            --clean-buildtrees-after-build --clean-packages-after-build \
+            --x-manifest-root test \
+            --x-feature test
+        shell: bash
+        env:
+          VCPKG_DEFAULT_TRIPLET: "x64-linux"
+
+      - name: "Run vcpkg(x64-windows)"
         if: runner.os == 'Windows'
         run: |
           vcpkg install --keep-going `
-            --clean-buildtrees-after-build `
-            --clean-packages-after-build `
+            --clean-buildtrees-after-build --clean-packages-after-build `
             --x-manifest-root test `
             --x-feature test
         shell: pwsh
         env:
-          VCPKG_BINARY_SOURCES: "${{ secrets.VCPKG_BINARY_SOURCES }}"
-          VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/ports"
-          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/triplets"
-          VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
+          VCPKG_DEFAULT_TRIPLET: "x64-windows"
+
+      - name: "Run vcpkg(arm64-windows)"
+        if: runner.os == 'Windows'
+        run: |
+          vcpkg install --keep-going `
+            --clean-buildtrees-after-build --clean-packages-after-build `
+            --x-manifest-root test `
+            --x-feature test
+        shell: pwsh
+        env:
+          VCPKG_DEFAULT_TRIPLET: "arm64-windows"
+        continue-on-error: true
 
   host-tools:
     name: "Host Tools"
     runs-on: ${{ matrix.runner_image }} # https://github.com/actions/runner-images
-    needs: validate
+    needs: [validate, overlay]
     strategy:
       matrix:
         include:
@@ -197,8 +228,7 @@ jobs:
       - name: "Run vcpkg(arm64-android)"
         run: |
           vcpkg install --keep-going \
-            --clean-buildtrees-after-build \
-            --clean-packages-after-build \
+            --clean-buildtrees-after-build --clean-packages-after-build \
             --x-manifest-root test \
             --x-feature test
         shell: bash
@@ -211,8 +241,7 @@ jobs:
       - name: "Run vcpkg(x64-android)"
         run: |
           vcpkg install --keep-going \
-            --clean-buildtrees-after-build \
-            --clean-packages-after-build \
+            --clean-buildtrees-after-build --clean-packages-after-build \
             --x-manifest-root test \
             --x-feature test
         shell: bash
@@ -225,7 +254,7 @@ jobs:
   vulkan:
     name: Vulkan
     runs-on: "windows-latest"
-    needs: validate
+    needs: overlay
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: aws-actions/configure-aws-credentials@v4
@@ -260,7 +289,7 @@ jobs:
   emscripten:
     name: "Emscripten"
     runs-on: "ubuntu-latest"
-    needs: validate
+    needs: overlay
     container:
       image: "emscripten/emsdk:3.1.74" # https://hub.docker.com/r/emscripten/emsdk
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,25 @@ env:
   VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests,versions"
 
 jobs:
-  # https://learn.microsoft.com/en-us/vcpkg/commands/install
-  # https://learn.microsoft.com/en-us/vcpkg/concepts/classic-mode
+  validate:
+    name: "Validate"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
+          vcpkgGitCommitId: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13
+      - name: "Run registry-format.ps1"
+        run: scripts/registry-format.ps1 -VcpkgRoot "${env:VCPKG_ROOT}" -RegistryRoot ${{ github.workspace }}
+        shell: pwsh
+      - name: "Run git diff"
+        run: git diff --exit-code
+
   overlay:
     name: "Overlay"
     runs-on: ${{ matrix.runner_image }} # https://github.com/actions/runner-images
+    needs: validate
     strategy:
       matrix:
         include:
@@ -112,6 +126,7 @@ jobs:
   host-tools:
     name: "Host Tools"
     runs-on: ${{ matrix.runner_image }} # https://github.com/actions/runner-images
+    needs: validate
     strategy:
       matrix:
         include:
@@ -163,6 +178,7 @@ jobs:
   android:
     name: "Android"
     runs-on: "ubuntu-latest" # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#environment-variables-2
+    needs: validate
     # container: # https://circleci.com/developer/images/image/cimg/android
     #   image: cimg/android:2025.01.1-ndk # 28.0.12674087
     steps:
@@ -209,6 +225,7 @@ jobs:
   vulkan:
     name: Vulkan
     runs-on: "windows-latest"
+    needs: validate
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: aws-actions/configure-aws-credentials@v4
@@ -243,6 +260,7 @@ jobs:
   emscripten:
     name: "Emscripten"
     runs-on: "ubuntu-latest"
+    needs: validate
     container:
       image: "emscripten/emsdk:3.1.74" # https://hub.docker.com/r/emscripten/emsdk
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,14 @@ env:
 jobs:
   validate:
     name: "Validate"
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: lukka/run-vcpkg@v11.5
-        with:
-          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
-          vcpkgGitCommitId: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13
       - name: "Run registry-format.ps1"
-        run: scripts/registry-format.ps1 -VcpkgRoot "${env:VCPKG_ROOT}" -RegistryRoot ${{ github.workspace }}
+        run: |
+          $env:VCPKG_ROOT="$env:VCPKG_INSTALLATION_ROOT"
+          $env:PATH="$env:VCPKG_ROOT:$env:PATH" # We are in Ubuntu!
+          scripts/registry-format.ps1 -VcpkgRoot "${env:VCPKG_ROOT}" -RegistryRoot ${{ github.workspace }}
         shell: pwsh
       - name: "Run git diff"
         run: git diff --exit-code

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: "Run gh(auth)"
-        run: gh auth status
+        run: |
+          gh auth status
+          gh extension install actions/gh-actions-cache
       - name: "Run gh-cleanup-cache.ps1"
         run: |
           $branch = "${{ github.event.pull_request.head.ref || github.event.inputs.branch }}"
@@ -34,7 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: "Run gh(auth)"
-        run: gh auth status
+        run: |
+          gh auth status
       - name: "Run gh-cleanup-runs.ps1"
         run: |
           $branch = "${{ github.event.pull_request.head.ref || github.event.inputs.branch }}"

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -2,22 +2,23 @@ name: Weekly Maintenance
 
 on:
   schedule:
-    - cron: "0 4 * * 0" # every sunday 04:00 UTC
+    - cron: "0 22 * * 5" # Every friday 10 PM
   workflow_dispatch:
 
 jobs:
   close-stale:
     name: "Close Stale Items"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
       pull-requests: write
+      contents: write
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 30
-          days-before-issue-close: 30
+          repo-token: ${{ secrets.GH_TOKEN }}
+          days-before-issue-stale: 21
+          days-before-issue-close: 7
           stale-issue-label: "stale"
-          days-before-pr-stale: 30
-          days-before-pr-close: 30
+          days-before-pr-stale: 21
+          days-before-pr-close: 7

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ buildtrees
 installed
 packages
 
+*.log
+
 # Created by https://www.toptal.com/developers/gitignore/api/cmake,c++,visualstudiocode,powershell
 # Edit at https://www.toptal.com/developers/gitignore?templates=cmake,c++,visualstudiocode,powershell
 

--- a/scripts/update-portfile-sha512.ps1
+++ b/scripts/update-portfile-sha512.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    PowerShell script to change `SHA512` string in the portfile.cmake
+.DESCRIPTION
+    Run `vcpkg install` with the given vcpkg port, then change the `SHA512` in the portfile.cmake to the 
+
+.PARAMETER PortName
+    The name of the port to try `vcpkg install` command
+.PARAMETER PortsDirectory
+    The path for `--overlay-ports` option of the `vcpkg install` command
+.PARAMETER LogFile
+    The path to store the output of the `vcpkg install` command
+
+.OUTPUTS
+    "${PortName} ${ActualHash}"
+
+.EXAMPLE
+    PS> update-portfile-sha512.ps1 -PortName abseil -PortsDirectory ports -LogFile install.log
+    abseil ${ActualHash}
+.EXAMPLE
+    PS> update-portfile-sha512.ps1 -PortName eigen3 -PortsDirectory "$(Get-Location)/ports" -LogFile install.log
+    eigen3 ${ActualHash}
+#>
+param (
+    [Parameter(Mandatory = $true)][string]$PortName,
+    [Parameter(Mandatory = $true)][string]$PortsDirectory,
+    [string]$PortFile = "$PortsDirectory/$PortName/portfile.cmake",
+    [Parameter(Mandatory = $true)][string]$LogFile
+)
+
+# Check if the PortFile exists
+if (-Not (Test-Path -Path $PortFile)) {
+    Write-Error "'$PortFile' does not exist."
+    exit 1
+}
+
+function ChangeSHA512 {
+    param (
+        [Parameter(Mandatory = $true)][string]$PortFile,
+        [string]$ReplacedHash = "0"
+    )
+    $Content = Get-Content -Path $PortFile
+    $Pattern = 'SHA512\s+[a-fA-F0-9]+'
+    $Replacement = "SHA512 $ReplacedHash"
+    $UpdatedContent = $Content -replace $Pattern, $Replacement
+    Set-Content -Path $PortFile -Value $UpdatedContent
+}
+
+function TryVcpkgInstall {
+    param (
+        [Parameter(Mandatory = $true)][string]$PortName,
+        [Parameter(Mandatory = $true)][string]$PortsDirectory,
+        [Parameter(Mandatory = $true)][string]$LogFile
+    )
+    try {
+        $InstallExpression = "vcpkg install --overlay-ports ${PortsDirectory} --editable ${PortName}"
+        $InstallOutput = Invoke-Expression $InstallExpression
+        Set-Content -Path $LogFile -Value $InstallOutput
+    } catch {
+        Write-Error "$_"
+        exit 1
+    }
+}
+
+function FindActualHash {
+    param (
+        [Parameter(Mandatory = $true)][string]$LogFile
+    )
+    $LogContent = Get-Content -Path $LogFile
+    $ActualHashPattern = 'Actual hash:\s+([a-fA-F0-9]+)'
+    [string]$MatchedLine = $LogContent -match $ActualHashPattern
+    # If failed to find actual hash, return empty string
+    if (-Not $MatchedLine) {
+        return ""
+    }
+    [string]$ActualHash = $MatchedLine.Substring(13)
+    return $ActualHash
+}
+
+# Step 1: Change the SHA512 value in the portfile.cmake to 0
+ChangeSHA512 -PortFile $PortFile -ReplacedHash "0"
+
+# Step 2: Run the vcpkg install command for the changed port and capture the output
+TryVcpkgInstall -PortName $PortName -PortsDirectory $PortsDirectory -LogFile $LogFile
+
+# Step 3: Parse the failure log to extract the Actual hash
+[string]$ActualHash = FindActualHash -LogFile $LogFile
+if (-Not $ActualHash) {
+    Write-Error "Failed to detect the actual SHA512 hash."
+    exit 1
+}
+
+# Step4: Change the SHA512 value in the portfile.cmake to the actual hash
+ChangeSHA512 -PortFile $PortFile -ReplacedHash $ActualHash
+
+Write-Output "$PortName $ActualHash"


### PR DESCRIPTION
### Changes

* Run "validate" job before running "overlay"
* The job "overlay" now uses 3 matrix items. Triplets became optional step with the runner.OS
* Reorganize job dependencies
* Fix cleanup.yml
* New script: update-portfile-sha512.ps1 to make ease of SHA512 change in portfile.cmake 

### References

* https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
