### PR TITLE
[llama-cpp] update to b4936

### DIFF
--- a/ports/llama-cpp/fix-3rdparty.patch
+++ b/ports/llama-cpp/fix-3rdparty.patch
@@ -1,53 +1,27 @@
 diff --git a/common/CMakeLists.txt b/common/CMakeLists.txt
-index e61015d..3bfac20 100644
+index 17146ff..c53e1b9 100644
 --- a/common/CMakeLists.txt
 +++ b/common/CMakeLists.txt
-@@ -64,7 +64,6 @@ add_library(${TARGET} STATIC
+@@ -63,7 +63,7 @@ add_library(${TARGET} STATIC
      console.cpp
      console.h
      json-schema-to-grammar.cpp
 -    json.hpp
++    # json.hpp
      llguidance.cpp
      log.cpp
      log.h
-@@ -77,6 +76,9 @@ add_library(${TARGET} STATIC
-     speculative.h
-     )
+@@ -82,6 +82,8 @@ if (BUILD_SHARED_LIBS)
+ endif()
  
+ set(LLAMA_COMMON_EXTRA_LIBS build_info)
 +find_package(nlohmann_json CONFIG REQUIRED)
 +target_link_libraries(${TARGET} PRIVATE nlohmann_json::nlohmann_json)
-+
- if (BUILD_SHARED_LIBS)
-     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
- endif()
-diff --git a/common/chat-template.hpp b/common/chat-template.hpp
-index 0e88fb3..1be8519 100644
---- a/common/chat-template.hpp
-+++ b/common/chat-template.hpp
-@@ -9,7 +9,7 @@
- #pragma once
  
- #include "minja.hpp"
--#include <json.hpp>
-+#include <nlohmann/json.hpp>
- #include <string>
- #include <vector>
- 
-diff --git a/common/chat.hpp b/common/chat.hpp
-index 33e64a4..7e2f658 100644
---- a/common/chat.hpp
-+++ b/common/chat.hpp
-@@ -3,7 +3,7 @@
- #pragma once
- 
- #include "common.h"
--#include <json.hpp>
-+#include <nlohmann/json.hpp>
- #include <optional>
- #include <string>
- #include <vector>
+ # Use curl to download model url
+ if (LLAMA_CURL)
 diff --git a/common/common.cpp b/common/common.cpp
-index 8661e16..6b9d80a 100644
+index 18ffb4e..2d0b6b1 100644
 --- a/common/common.cpp
 +++ b/common/common.cpp
 @@ -9,7 +9,7 @@
@@ -56,11 +30,11 @@ index 8661e16..6b9d80a 100644
  #define JSON_ASSERT GGML_ASSERT
 -#include "json.hpp"
 +#include <nlohmann/json.hpp>
- #include "json-schema-to-grammar.h"
  #include "llama.h"
- #include "chat.hpp"
+ 
+ #include <algorithm>
 diff --git a/common/json-schema-to-grammar.h b/common/json-schema-to-grammar.h
-index 62a3b0a..81fdcff 100644
+index 4613f5d..6763e6d 100644
 --- a/common/json-schema-to-grammar.h
 +++ b/common/json-schema-to-grammar.h
 @@ -3,7 +3,7 @@
@@ -72,10 +46,23 @@ index 62a3b0a..81fdcff 100644
  
  std::string json_schema_to_grammar(const nlohmann::ordered_json & schema,
                                     bool force_gbnf = false);
-diff --git a/common/minja.hpp b/common/minja.hpp
-index c304b5c..1480087 100644
---- a/common/minja.hpp
-+++ b/common/minja.hpp
+diff --git a/common/minja/chat-template.hpp b/common/minja/chat-template.hpp
+index 882ba41..6ed9d4d 100644
+--- a/common/minja/chat-template.hpp
++++ b/common/minja/chat-template.hpp
+@@ -9,7 +9,7 @@
+ #pragma once
+ 
+ #include "minja.hpp"
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/common/minja/minja.hpp b/common/minja/minja.hpp
+index fa4c34d..47aa4ac 100644
+--- a/common/minja/minja.hpp
++++ b/common/minja/minja.hpp
 @@ -16,7 +16,7 @@
  #include <stdexcept>
  #include <sstream>
@@ -86,31 +73,30 @@ index c304b5c..1480087 100644
  using json = nlohmann::ordered_json;
  
 diff --git a/examples/server/CMakeLists.txt b/examples/server/CMakeLists.txt
-index 1b7cc8c..e1a9cad 100644
+index aee9038..294a18b 100644
 --- a/examples/server/CMakeLists.txt
 +++ b/examples/server/CMakeLists.txt
-@@ -12,7 +12,6 @@ endif()
+@@ -12,7 +12,7 @@ endif()
  set(TARGET_SRCS
      server.cpp
      utils.hpp
 -    httplib.h
++    # httplib.h
  )
  set(PUBLIC_ASSETS
      index.html.gz
-@@ -34,7 +33,10 @@ endforeach()
- add_executable(${TARGET} ${TARGET_SRCS})
- install(TARGETS ${TARGET} RUNTIME)
- 
--target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
-+# find_path(CPPHTTPLIB_INCLUDE_DIRS NAMES "httplib.h" REQUIRED)
-+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR} ${CPPHTTPLIB_INCLUDE_DIRS})
-+find_package(CURL REQUIRED)
-+target_link_libraries(${TARGET} PRIVATE CURL::libcurl)
+@@ -37,6 +37,9 @@ install(TARGETS ${TARGET} RUNTIME)
+ target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
  target_link_libraries(${TARGET} PRIVATE common ${CMAKE_THREAD_LIBS_INIT})
  
++find_package(httplib CONFIG REQUIRED)
++target_link_libraries(${TARGET} PRIVATE httplib::httplib)
++
  if (LLAMA_SERVER_SSL)
+     find_package(OpenSSL REQUIRED)
+     target_link_libraries(${TARGET} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 diff --git a/examples/server/server.cpp b/examples/server/server.cpp
-index 9cdf205..bfc05bc 100644
+index c2f1afe..d9625ee 100644
 --- a/examples/server/server.cpp
 +++ b/examples/server/server.cpp
 @@ -10,7 +10,7 @@
@@ -123,15 +109,20 @@ index 9cdf205..bfc05bc 100644
  #define MIMETYPE_JSON "application/json; charset=utf-8"
  
 diff --git a/examples/server/utils.hpp b/examples/server/utils.hpp
-index 5f97df5..db2a42f 100644
+index 58cdd6a..2898e62 100644
 --- a/examples/server/utils.hpp
 +++ b/examples/server/utils.hpp
-@@ -11,7 +11,7 @@
+@@ -9,11 +9,11 @@
+ #define CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH 1048576
+ // disable Nagle's algorithm
+ #define CPPHTTPLIB_TCP_NODELAY true
+-#include "httplib.h"
++#include <httplib.h>
  
  // Change JSON_ASSERT from assert() to GGML_ASSERT:
  #define JSON_ASSERT GGML_ASSERT
 -#include "json.hpp"
 +#include <nlohmann/json.hpp>
- #include "minja.hpp"
- #include "chat.hpp"
- #include "chat-template.hpp"
+ #include "chat.h"
+ 
+ #include <random>

--- a/ports/llama-cpp/fix-3rdparty.patch
+++ b/ports/llama-cpp/fix-3rdparty.patch
@@ -85,13 +85,17 @@ index aee9038..294a18b 100644
  )
  set(PUBLIC_ASSETS
      index.html.gz
-@@ -37,6 +37,9 @@ install(TARGETS ${TARGET} RUNTIME)
+@@ -37,6 +37,13 @@ install(TARGETS ${TARGET} RUNTIME)
  target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
  target_link_libraries(${TARGET} PRIVATE common ${CMAKE_THREAD_LIBS_INIT})
  
 +find_package(httplib CONFIG REQUIRED)
-+target_link_libraries(${TARGET} PRIVATE httplib::httplib)
-+
++find_package(ZLIB REQUIRED)
++target_link_libraries(${TARGET} PRIVATE httplib::httplib ZLIB::ZLIB)
++if(APPLE)
++    find_library(SYSTEMCONFIGURATION SystemConfiguration REQUIRED)
++    target_link_libraries(${TARGET} PRIVATE ${SYSTEMCONFIGURATION})
++endif()
  if (LLAMA_SERVER_SSL)
      find_package(OpenSSL REQUIRED)
      target_link_libraries(${TARGET} PRIVATE OpenSSL::SSL OpenSSL::Crypto)

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -3,11 +3,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled) # there are some python scripts
 
+# https://github.com/ggml-org/llama.cpp/releases/tag/b4936
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggerganov/llama.cpp
     REF "b${VERSION}"
-    SHA512 d939bb35e492dba06068e49dd0b28e8352fcbf598c1d7198fdedb405893b4c3a90b3709f0c57e57ffe3e92860d7c5ad21a2cc1129d50c07f27470b8b37d87183
+    SHA512 76a1bed0fa543651a90003245a7947d4cf80a172f3198a364260b37fd825e0f1d7e2222eaeb6226a322a8e2ba5a7e0243ecc9bcca576699c13bde7d61a4b8d57
     HEAD_REF master
     PATCHES
         fix-cmake-ggml.patch
@@ -16,7 +17,7 @@ vcpkg_from_github(
 )
 file(REMOVE
     "${SOURCE_PATH}/common/json.hpp" # nlohmann-json
-    # "${SOURCE_PATH}/examples/server/httplib.h" # todo: use cpp-httplib[openssl]
+    "${SOURCE_PATH}/examples/server/httplib.h" # cpp-httplib
 )
 
 vcpkg_find_acquire_program(GIT)
@@ -132,6 +133,8 @@ vcpkg_cmake_configure(
     OPTIONS_RELEASE
         -DGGML_METAL_NDEBUG=ON
         -DGGML_METAL_SHADER_DEBUG=OFF
+    MAYBE_UNUSED_VARIABLES
+        LLAMA_SERVER_SSL
 )
 vcpkg_cmake_install()
 

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-cpp",
-  "version": "4644",
+  "version": "4936",
   "description": "LLM inference in C/C++",
   "homepage": "https://github.com/ggerganov/llama.cpp",
   "license": "MIT",
@@ -43,15 +43,18 @@
       ]
     },
     "openmp": {
-      "description": "Use OpenMP",
-      "dependencies": [
-        "openmp"
-      ]
+      "description": "Use OpenMP"
     },
     "server": {
       "description": "Build llama server",
       "supports": "windows | linux | osx",
       "dependencies": [
+        {
+          "name": "cpp-httplib",
+          "features": [
+            "openssl"
+          ]
+        },
         {
           "name": "curl",
           "features": [

--- a/test/self-hosted.json
+++ b/test/self-hosted.json
@@ -37,16 +37,16 @@
       "description": "Default ports to test",
       "dependencies": [
         {
-          "name": "godot",
+          "name": "d3d12-transition-layer",
           "features": [
-            "spine-runtimes"
+            "pix"
           ],
           "platform": "x64 & windows"
         },
         {
-          "name": "d3d12-transition-layer",
+          "name": "godot",
           "features": [
-            "pix"
+            "spine-runtimes"
           ],
           "platform": "x64 & windows"
         },
@@ -54,7 +54,9 @@
         {
           "name": "llama-cpp",
           "features": [
-            "opencl"
+            "opencl",
+            "openmp",
+            "server"
           ]
         },
         {

--- a/test/vcpkg-configuration.json
+++ b/test/vcpkg-configuration.json
@@ -3,8 +3,8 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/Microsoft/vcpkg",
-    "reference": "2025.01.13",
-    "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836"
+    "reference": "2025.03.19",
+    "baseline": "b02e341c927f16d991edbd915d8ea43eac52096c"
   },
   "registries": []
 }

--- a/test/vcpkg-configuration.json
+++ b/test/vcpkg-configuration.json
@@ -3,8 +3,8 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/Microsoft/vcpkg",
-    "reference": "2025.03.19",
-    "baseline": "b02e341c927f16d991edbd915d8ea43eac52096c"
+    "reference": "master",
+    "baseline": "b9d5c69154a5efe413d29da8c52bfeb14aabfb08"
   },
   "registries": []
 }

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -63,7 +63,6 @@
           "name": "libdispatch",
           "platform": "windows | android"
         },
-        "llama-cpp",
         {
           "name": "llama-cpp",
           "features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,7 +101,7 @@
       "port-version": 0
     },
     "llama-cpp": {
-      "baseline": "4644",
+      "baseline": "4936",
       "port-version": 0
     },
     "metal-cpp": {

--- a/versions/l-/llama-cpp.json
+++ b/versions/l-/llama-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "04bbfed535e660ff2b208e88256d22529bfdf4fb",
+      "git-tree": "c99ef10c0503db35dca8c422b6af609f4ab65e22",
       "version": "4936",
       "port-version": 0
     },

--- a/versions/l-/llama-cpp.json
+++ b/versions/l-/llama-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04bbfed535e660ff2b208e88256d22529bfdf4fb",
+      "version": "4936",
+      "port-version": 0
+    },
+    {
       "git-tree": "0012ab010bbdfe4574d65aab2555f5faf5cc1e4a",
       "version": "4644",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Resolve https://github.com/luncliff/vcpkg-registry/issues/337
* Fixed `openmp` feature dependency
* use `cpp-httplib` in `server` feature 

### References

* https://github.com/ggml-org/llama.cpp/releases/tag/b4936
