### PR TITLE
[metal-cpp] update to macOS15_iOS18 

### DIFF
--- a/ports/metal-cpp/portfile.cmake
+++ b/ports/metal-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 # see https://github.com/bkaradzic/metal-cpp
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18-beta.zip"
-    FILENAME metal-cpp_macOS15_iOS18-beta.zip
-    SHA512 401a38c9268a772c2586da9269e9eab42f8d5643d36b7bce07fe815c1efc56ae1fd1742513e2c5126487dd5326e25e6a503830347de17cc0c563e493dff709a4
+    URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_${VERSION}.zip"
+    FILENAME metal-cpp_${VERSION}.zip
+    SHA512 5b24953eb70f128062faca8f0a0130fcb6e0b837427c75d32930f6a4146b87413b5c4195cffbbbf13024f878ea2883817113df54550885daa90238ab372ffe4c
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/metal-cpp/vcpkg.json
+++ b/ports/metal-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-cpp",
-  "version-string": "macOS15_iOS18-beta",
+  "version-string": "macOS15_iOS18",
   "description": "Metal-cpp is a low-overhead C++ interface for Metal that helps developers add Metal functionality to graphics apps, games, and game engines that are written in C++.",
   "homepage": "https://developer.apple.com/metal/cpp/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,7 +105,7 @@
       "port-version": 0
     },
     "metal-cpp": {
-      "baseline": "macOS15_iOS18-beta",
+      "baseline": "macOS15_iOS18",
       "port-version": 0
     },
     "miniaudio": {

--- a/versions/m-/metal-cpp.json
+++ b/versions/m-/metal-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2089d6a29ba21ed7cca1b7ba927c69ff076c274",
+      "version-string": "macOS15_iOS18",
+      "port-version": 0
+    },
+    {
       "git-tree": "45d5dc22fc5eb964a7f0186f19cf28003fef166f",
       "version-string": "macOS15_iOS18-beta",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Use more later version in https://developer.apple.com/metal/cpp/

Future works
* update to https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15.2_iOS18.2.zip

### References

* https://github.com/bkaradzic/metal-cpp/tree/metal-cpp_macOS15_iOS18
* #271 

### Triplet Support

All Apple platform triplets