### PR TITLE
[metal-cpp] update to macOS15.2_iOS18.2

### DIFF
--- a/ports/metal-cpp/portfile.cmake
+++ b/ports/metal-cpp/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://developer.apple.com/metal/cpp/files/metal-cpp_${VERSION}.zip"
     FILENAME metal-cpp_${VERSION}.zip
-    SHA512 5b24953eb70f128062faca8f0a0130fcb6e0b837427c75d32930f6a4146b87413b5c4195cffbbbf13024f878ea2883817113df54550885daa90238ab372ffe4c
+    SHA512 6a539e7bff5eb6d16176e3565f07f18f157eb69ca7c478a5ee9b0400aed84672632dc7e8b6d8d452d49c434bbe6a04bb1579756bf3564ee6163c67b87d967513
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/metal-cpp/vcpkg.json
+++ b/ports/metal-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-cpp",
-  "version-string": "macOS15_iOS18",
+  "version-string": "macOS15.2_iOS18.2",
   "description": "Metal-cpp is a low-overhead C++ interface for Metal that helps developers add Metal functionality to graphics apps, games, and game engines that are written in C++.",
   "homepage": "https://developer.apple.com/metal/cpp/",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,7 +105,7 @@
       "port-version": 0
     },
     "metal-cpp": {
-      "baseline": "macOS15_iOS18",
+      "baseline": "macOS15.2_iOS18.2",
       "port-version": 0
     },
     "miniaudio": {

--- a/versions/m-/metal-cpp.json
+++ b/versions/m-/metal-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19026ef18081c8bb23a9c2449ab7025f5c187c96",
+      "version-string": "macOS15.2_iOS18.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2089d6a29ba21ed7cca1b7ba927c69ff076c274",
       "version-string": "macOS15_iOS18",
       "port-version": 0


### PR DESCRIPTION
### Changes

* Use more later version in https://developer.apple.com/metal/cpp/

### References

* #343
* https://github.com/bkaradzic/metal-cpp/tree/metal-cpp_macOS15.2_iOS18.2

### Triplet Support

All Apple platform triplets