### PR TITLE
[opencl,opencl-headers] Update to v2024.10.24

### DIFF
--- a/ports/opencl-headers/portfile.cmake
+++ b/ports/opencl-headers/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH CL_SOURCE_PATH
     REPO KhronosGroup/OpenCL-Headers
-    REF v2024.05.08
-    SHA512 2f1a46d58a5a9329470bab4c3662f17e81aab9558bfd9e1aafa14d3e1ab129513ab9493eeeb3cc48f0f91f0bc6b61bd54e28d7083eed58af9f34cd973cc93de1
+    REF ${VERSION}
+    SHA512 9d2ed2a8346bc3f967989091d8cc36148ffe5ff13fe30e12354cc8321c09328bbe23e74817526b99002729c884438a3b1834e175a271f6d36e8341fd86fc1ad5
     HEAD_REF main
     PATCHES
         fix-headers.patch
@@ -22,8 +22,8 @@ vcpkg_fixup_pkgconfig() # OpenCL-Headers
 vcpkg_from_github(
     OUT_SOURCE_PATH CLHPP_SOURCE_PATH
     REPO KhronosGroup/OpenCL-CLHPP
-    REF v2024.05.08
-    SHA512 6396cd67a2edef6a76695857e3e45f7eeb8cdaa8c729197357c6374ac58b41caa37bbe8c3b7a1724d43d3805f8cd5edd53a8ed833d6415bf072745800b744572
+    REF ${VERSION}
+    SHA512 7cdadc8ef182d1556346bd34b5a9ffe6e239ab61ec527e5609d69e1bcaf81a88f3fc534f5bdeed037236e1b0e61f1544d2a95c06df55f9cd8e03e13baf4143ba
     HEAD_REF main
 )
 

--- a/ports/opencl-headers/vcpkg.json
+++ b/ports/opencl-headers/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "opencl-headers",
-  "version-string": "v2024.05.08",
-  "port-version": 1,
+  "version-string": "v2024.10.24",
   "description": "Khronos OpenCL-Headers",
   "homepage": "https://github.com/KhronosGroup/OpenCL-Headers",
   "supports": "!uwp",

--- a/ports/opencl/portfile.cmake
+++ b/ports/opencl/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/OpenCL-ICD-Loader
-    REF v2024.05.08
-    SHA512 12d62183e49c5a1f813807291744d816008afca55b09f5acf2eef1bce50a453bf35a8dfbeb5f433022b0c5517f0a210d7123a3bac7a15ea63cc10f3bc71510f0
+    REF ${VERSION}
+    SHA512 29043eff21076440046314edf62bb488b7e4e17d9fbdac4c3727d8e2523c0c8fbf89ee7fcf762528af761ddbcb4be24e5f062ffa82f778401d6365faa35344a8
     HEAD_REF main
 )
 
@@ -12,15 +12,13 @@ vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
     -DENABLE_OPENCL_LAYERINFO=OFF
-    -DOPENCL_ICD_LOADER_HEADERS_DIR:PATH=${CURRENT_INSTALLED_DIR}/include
+    "-DOPENCL_ICD_LOADER_HEADERS_DIR:PATH=${CURRENT_INSTALLED_DIR}/include"
 )
 
 vcpkg_cmake_build(TARGET OpenCL)
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/OpenCLICDLoader PACKAGE_NAME OpenCLICDLoader)
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_fixup_pkgconfig()
-endif()
+vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE

--- a/ports/opencl/vcpkg.json
+++ b/ports/opencl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opencl",
-  "version-string": "v2024.05.08",
+  "version-string": "v2024.10.24",
   "description": "C/C++ headers and ICD loader (Installable Client Driver) for OpenCL",
   "homepage": "https://github.com/KhronosGroup/OpenCL-ICD-Loader",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -173,12 +173,12 @@
       "port-version": 0
     },
     "opencl": {
-      "baseline": "v2024.05.08",
+      "baseline": "v2024.10.24",
       "port-version": 0
     },
     "opencl-headers": {
-      "baseline": "v2024.05.08",
-      "port-version": 1
+      "baseline": "v2024.10.24",
+      "port-version": 0
     },
     "opencl-on-dx12": {
       "baseline": "1.2404.1.0",

--- a/versions/o-/opencl-headers.json
+++ b/versions/o-/opencl-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e99294a96d3f1c4b58207b06daad1f41e31971a5",
+      "version-string": "v2024.10.24",
+      "port-version": 0
+    },
+    {
       "git-tree": "c9153f19951639bf50146929acffc4eb930d04ca",
       "version-string": "v2024.05.08",
       "port-version": 1

--- a/versions/o-/opencl.json
+++ b/versions/o-/opencl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa42c2197f28740e383d5fdce229da1fb7de85ab",
+      "version-string": "v2024.10.24",
+      "port-version": 0
+    },
+    {
       "git-tree": "26ef38df7478ecffa1390e02d859387617b4832e",
       "version-string": "v2024.05.08",
       "port-version": 0


### PR DESCRIPTION
### Changes

Bump to later release.

* CMake 4.0 fails to build the old version

### References

* #204 
* https://github.com/KhronosGroup/OpenCL-Headers/releases/tag/v2024.10.24
* https://github.com/KhronosGroup/OpenCL-CLHPP/releases/tag/v2024.10.24
* https://github.com/KhronosGroup/OpenCL-ICD-Loader/releases/tag/v2024.10.24
