### PR TITLE
[nvidia-cnmem] Change `cmake_minimum_required` for CMake 4.0

### DIFF
--- a/ports/nvidia-cnmem/fix-cmake.patch
+++ b/ports/nvidia-cnmem/fix-cmake.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 47c02b0..a3b2393 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,17 +1,16 @@
+ # CMakeLists to build the cnmem library.
+-cmake_minimum_required(VERSION 2.8.8)
++cmake_minimum_required(VERSION 3.6)
+ project(cnmem)
+ 
+ # We need CUDA to build that library.
+-find_package(CUDA QUIET REQUIRED)
+-include_directories(${CUDA_INCLUDE_DIRS})
++find_package(CUDA REQUIRED)
+ 
+ # Rules to build the cnmem library.
+-include_directories(include)
+-add_definitions(-DCNMEM_DLLEXPORT)
+ add_library(cnmem SHARED src/cnmem.cpp)
+ set_target_properties(cnmem PROPERTIES VERSION 1.0.0 SOVERSION 1)
+-target_link_libraries(cnmem LINK_PUBLIC ${CUDA_LIBRARIES})
++target_link_libraries(cnmem PUBLIC ${CUDA_LIBRARIES})
++target_include_directories(cnmem PRIVATE include ${CUDA_INCLUDE_DIRS})
++target_compile_definitions(cnmem PRIVATE CNMEM_DLLEXPORT)
+ install(TARGETS cnmem RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
+ install(FILES include/cnmem.h DESTINATION include)
+ 

--- a/ports/nvidia-cnmem/portfile.cmake
+++ b/ports/nvidia-cnmem/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 37896cc9bfc6536a8c878a1e675835c22d827821
     SHA512 f6266c94041a546add582c2ad2a93dc7bfdd4c37fdd62df720b8c212249d1513ee89d975f3d0b1e555a911441abdc79c117ff6d8ca82563eaf6cbcc9140b8584
     HEAD_REF master
+    PATCHES
+        fix-cmake.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/nvidia-cnmem/vcpkg.json
+++ b/ports/nvidia-cnmem/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nvidia-cnmem",
   "version-date": "2018-11-28",
+  "port-version": 1,
   "description": "A simple memory manager for CUDA designed to help Deep Learning frameworks manage memory",
   "homepage": "https://github.com/NVIDIA/cnmem",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -130,7 +130,7 @@
     },
     "nvidia-cnmem": {
       "baseline": "2018-11-28",
-      "port-version": 0
+      "port-version": 1
     },
     "nvidia-cudnn-frontend": {
       "baseline": "1.11.0",

--- a/versions/n-/nvidia-cnmem.json
+++ b/versions/n-/nvidia-cnmem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0075dadcedd68b72f5f55a5802a5d82e3c0a9240",
+      "version-date": "2018-11-28",
+      "port-version": 1
+    },
+    {
       "git-tree": "f97ff402e15197be7c366cc7b8cb4c2413b40b25",
       "version-date": "2018-11-28",
       "port-version": 0


### PR DESCRIPTION
### Changes

Support CMake configure with CMake 4.0 version

### References

* https://cmake.org/cmake/help/v4.0/release/4.0.html
* https://github.com/NVIDIA/cnmem/commit/37896cc9bfc6536a8c878a1e675835c22d827821
