### PR TITLE
[coreml-tools] install modelpackage headers

### DIFF
--- a/ports/coreml-tools/fix-cmake.patch
+++ b/ports/coreml-tools/fix-cmake.patch
@@ -1,7 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d462525..315a9ee 100644
+index d462525..49ad381 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2)
+ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+ 
+ project(coremltools)
+-
++include(GNUInstallDirs)
+ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+   message(FATAL_ERROR "
+     Source directory '${PROJECT_SOURCE_DIR}' is the same
 @@ -31,7 +31,14 @@ if(HAS_CCACHE)
    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
  endif()
@@ -53,17 +62,18 @@ index d462525..315a9ee 100644
  
  target_link_libraries(milstoragepython
    mlmodel
-@@ -70,7 +84,8 @@ add_library(modelpackage
+@@ -70,7 +84,9 @@ add_library(modelpackage
    modelpackage/src/utils/JsonMap.cpp
    modelpackage/src/ModelPackagePython.cpp
    )
 -  
 +install(TARGETS modelpackage DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(FILES modelpackage/src/ModelPackage.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/modelpackage/src)
 +
  target_compile_definitions(modelpackage
    PRIVATE
    CPU_ONLY=1
-@@ -78,7 +93,6 @@ target_compile_definitions(modelpackage
+@@ -78,7 +94,6 @@ target_compile_definitions(modelpackage
  
  target_link_libraries(modelpackage
    mlmodel
@@ -71,7 +81,32 @@ index d462525..315a9ee 100644
    )
  
  if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
-@@ -157,6 +171,7 @@ if (APPLE AND CORE_VIDEO AND CORE_ML AND FOUNDATION)
+@@ -111,22 +126,11 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+   set(_additional_modelpackage_command COMMAND strip -x ${PROJECT_SOURCE_DIR}/coremltools/libmodelpackage.so)
+ endif()
+ 
+-add_custom_command(
+-  TARGET modelpackage
+-  POST_BUILD
+-  COMMAND cp $<TARGET_FILE:modelpackage> ${PROJECT_SOURCE_DIR}/coremltools/libmodelpackage.so
+-  ${_additional_modelpackage_command}
+-)
+ if (NOT APPLE)
+-  target_link_libraries(modelpackage uuid)
++  find_library(UUID NAMES uuid REQUIRED)
++  target_link_libraries(modelpackage ${UUID})
+ endif()
+ 
+-add_custom_command(
+-  TARGET milstoragepython
+-  POST_BUILD
+-  COMMAND cp $<TARGET_FILE:milstoragepython> ${PROJECT_SOURCE_DIR}/coremltools/libmilstoragepython.so
+-  ${_additional_milstoragepython_command}
+-)
+ 
+ find_library(CORE_VIDEO CoreVideo)
+ find_library(CORE_ML CoreML)
+@@ -157,6 +161,7 @@ if (APPLE AND CORE_VIDEO AND CORE_ML AND FOUNDATION)
      coremlpython/CoreMLPythonUtils.mm
      coremlpython/CoreMLPythonUtils.h
    )
@@ -80,7 +115,7 @@ index d462525..315a9ee 100644
      mlmodel
      ${CORE_VIDEO}
 diff --git a/cmake/coreml-utils.cmake b/cmake/coreml-utils.cmake
-index ab4679c..e988cda 100644
+index ab4679c..3d5ef6f 100644
 --- a/cmake/coreml-utils.cmake
 +++ b/cmake/coreml-utils.cmake
 @@ -20,45 +20,43 @@
@@ -140,7 +175,7 @@ index ab4679c..e988cda 100644
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
      )
      # For the CoreML framework we read the source file locations for these, and
-@@ -67,36 +64,28 @@ function(coreml_add_build_proto proto_fn target_suffix)
+@@ -67,36 +65,28 @@ function(coreml_add_build_proto proto_fn target_suffix)
      if(OVERWRITE_PB_SOURCE)
          add_custom_target(tgt_${proto_fn}_source ALL
              COMMENT "Generating c++ sources from ${proto_fn}.proto into ${CMAKE_CURRENT_SOURCE_DIR}/build/format/"

--- a/ports/coreml-tools/vcpkg.json
+++ b/ports/coreml-tools/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "coreml-tools",
   "version": "8.2",
+  "port-version": 1,
   "description": "Core ML tools contain supporting tools for Core ML model conversion, editing, and validation.",
-  "homepage": "https://coremltools.readme.io/",
+  "homepage": "https://github.com/apple/coremltools",
   "license": "BSD-3-Clause",
   "supports": "osx | ios",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -22,7 +22,7 @@
     },
     "coreml-tools": {
       "baseline": "8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cpuinfo": {
       "baseline": "2024-10-23",

--- a/versions/c-/coreml-tools.json
+++ b/versions/c-/coreml-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8064fde05ff3f3b2865c2812d146f74eb683b911",
+      "version": "8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bec56b197511c03b8b9fb6be83f13a68988c3ec9",
       "version": "8.2",
       "port-version": 0


### PR DESCRIPTION
### Changes

```./packages/coreml-tools_arm64-osx/
├── BUILD_INFO
├── CONTROL
├── debug
│   └── lib
│       ├── libcoremlpython.dylib
│       ├── libmilstoragepython.dylib
│       ├── libmlmodel.a
│       └── libmodelpackage.dylib
├── include
│   ├── mlmodel
│   │   └── format
│   │       ├── ArrayFeatureExtractor.pb.h
│   │       ├── ArrayFeatureExtractor.proto
│   │       ├── ...
│   │       └── WordTagger_enums.h
│   └── modelpackage
│       └── src
│           └── ModelPackage.hpp
├── lib
│   ├── libcoremlpython.dylib
│   ├── libmilstoragepython.dylib
│   ├── libmlmodel.a
│   └── libmodelpackage.dylib
├── share
│   └── coreml-tools
│       ├── copyright
│       └── vcpkg.spdx.json
└── tools
    └── coreml-tools
        ├── enumgen
        └── mlmodel_test_runner

13 directories, 114 files
```

### References

* #311 
* https://github.com/apple/coremltools/releases/tag/8.2

### Triplet Support

* `x64-osx`
* `arm64-osx`
* `arm64-ios`
