### PR TITLE
[tensorflow-lite] Fix OpenCL 2024.10.24 build error

### DIFF
--- a/ports/tensorflow-lite/fix-sources.patch
+++ b/ports/tensorflow-lite/fix-sources.patch
@@ -25,3 +25,16 @@ index 916be8db..e2df0d5f 100644
  
  namespace tsl {
  using float8_e4m3fn = ::ml_dtypes::float8_e4m3fn;
+diff --git a/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h b/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h
+index cbdf46a0..ef618c16 100644
+--- a/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h
++++ b/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h
+@@ -547,7 +547,7 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueCommandBufferKHR)(
+ typedef cl_int(CL_API_CALL *PFN_clCommandNDRangeKernelKHR)(
+     cl_command_buffer_khr /*command_buffer*/,
+     cl_command_queue /*command_queue*/,
+-    const cl_ndrange_kernel_command_properties_khr * /*properties*/,
++    const cl_command_properties_khr * /*properties*/,
+     cl_kernel /*kernel*/, cl_uint /*work_dim*/,
+     const size_t * /*global_work_offset*/, const size_t * /*global_work_size*/,
+     const size_t * /*local_work_size*/,

--- a/ports/tensorflow-lite/fix-sources.patch
+++ b/ports/tensorflow-lite/fix-sources.patch
@@ -26,15 +26,39 @@ index 916be8db..e2df0d5f 100644
  namespace tsl {
  using float8_e4m3fn = ::ml_dtypes::float8_e4m3fn;
 diff --git a/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h b/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h
-index cbdf46a0..ef618c16 100644
+index cbdf46a0..c5cd674b 100644
 --- a/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h
 +++ b/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h
-@@ -547,7 +547,7 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueCommandBufferKHR)(
+@@ -544,10 +544,11 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueCommandBufferKHR)(
+     cl_uint /*num_events_in_wait_list*/, const cl_event * /*event_wait_list*/,
+     cl_event * /*event*/);
+ 
++#if defined(CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION) // CL_MAKE_VERSION(0, 9, 5)
  typedef cl_int(CL_API_CALL *PFN_clCommandNDRangeKernelKHR)(
      cl_command_buffer_khr /*command_buffer*/,
      cl_command_queue /*command_queue*/,
 -    const cl_ndrange_kernel_command_properties_khr * /*properties*/,
-+    const cl_command_properties_khr * /*properties*/,
++    const cl_command_buffer_flags_khr * /*properties*/, // new in OpenCL 2024.10.24
      cl_kernel /*kernel*/, cl_uint /*work_dim*/,
      const size_t * /*global_work_offset*/, const size_t * /*global_work_size*/,
      const size_t * /*local_work_size*/,
+@@ -555,6 +556,19 @@ typedef cl_int(CL_API_CALL *PFN_clCommandNDRangeKernelKHR)(
+     const cl_sync_point_khr * /*sync_point_wait_list*/,
+     cl_sync_point_khr * /*sync_point*/,
+     cl_mutable_command_khr * /*mutable_handle*/);
++#else // for OpenCL 2024.05.08
++typedef cl_int(CL_API_CALL *PFN_clCommandNDRangeKernelKHR)(
++    cl_command_buffer_khr /*command_buffer*/,
++    cl_command_queue /*command_queue*/,
++    const cl_ndrange_kernel_command_properties_khr * /*properties*/, // renamed to cl_command_buffer_flags_khr in OpenCL 2024.10.24
++    cl_kernel /*kernel*/, cl_uint /*work_dim*/,
++    const size_t * /*global_work_offset*/, const size_t * /*global_work_size*/,
++    const size_t * /*local_work_size*/,
++    cl_uint /*num_sync_points_in_wait_list*/,
++    const cl_sync_point_khr * /*sync_point_wait_list*/,
++    cl_sync_point_khr * /*sync_point*/,
++    cl_mutable_command_khr * /*mutable_handle*/);
++#endif
+ 
+ typedef cl_int(CL_API_CALL *PFN_clGetCommandBufferInfoKHR)(
+     cl_command_buffer_khr /*command_buffer*/,

--- a/ports/tensorflow-lite/vcpkg.json
+++ b/ports/tensorflow-lite/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tensorflow-lite",
   "version-semver": "2.18.1",
+  "port-version": 1,
   "description": "An Open Source Machine Learning Framework for Everyone",
   "homepage": "https://github.com/tensorflow/tensorflow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -234,7 +234,7 @@
     },
     "tensorflow-lite": {
       "baseline": "2.18.1",
-      "port-version": 0
+      "port-version": 1
     },
     "tensorpipe": {
       "baseline": "2022-05-14",

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "fef0b4d9a170484026518adce692a0a184722e71",
+      "git-tree": "bc18dfe296fe1240bd8ea5693513cf0532ba0b63",
       "version-semver": "2.18.1",
       "port-version": 1
     },
     {
-      "git-tree": "d5488c321649e0f200f21fc8e5d4968849359e79",
+      "git-tree": "d8851e512ec362a215bb0efe5698fdb11415f1e9",
       "version-semver": "2.18.1",
       "port-version": 0
     },

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fef0b4d9a170484026518adce692a0a184722e71",
+      "version-semver": "2.18.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d5488c321649e0f200f21fc8e5d4968849359e79",
       "version-semver": "2.18.1",
       "port-version": 0

--- a/versions/t-/tensorflow-lite.json
+++ b/versions/t-/tensorflow-lite.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "d8851e512ec362a215bb0efe5698fdb11415f1e9",
+      "git-tree": "d5488c321649e0f200f21fc8e5d4968849359e79",
       "version-semver": "2.18.1",
       "port-version": 0
     },


### PR DESCRIPTION
### Changes

* see https://github.com/KhronosGroup/OpenCL-Headers/releases/tag/v2024.10.24

> The `cl_ndrange_kernel_command_properties_khr` type was generalized and renamed to `cl_command_properties_khr`.

The new version defines [macro `CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION`](https://github.com/KhronosGroup/OpenCL-Headers/blob/4ea6df132107e3b4b9407f903204b5522fdffcd6/CL/cl_ext.h#L55) in `CL/cl_ext.h`.
Use this to distinguish new/old OpenCL Header version

* Before https://github.com/KhronosGroup/OpenCL-Headers/blob/v2024.05.08/CL/cl_ext.h#L47-L52
* After https://github.com/KhronosGroup/OpenCL-Headers/blob/v2024.10.24/CL/cl_ext.h#L47-L55

### References

* #349 

