### PR TITLE
[abseil] update to 20250127.1

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO abseil/abseil-cpp
     REF "${VERSION}"
-    SHA512 2a021faad807ee3e23548716ffa4785dc2409edbb4be676cc4bc01d47885760de340f0a4afdcbf0aaa835affd6d78f7bc319bbf7d337dbc30e7a559d0088e4bd
+    SHA512 8312acf0ed74fa28c6397f3e41ada656dbd5ca2bf8db484319d74b144ad19c0ebdc77f7f03436be6c6ca1cde706b9055079233cf0d6b5ada4ca48406f8a55dd8
     HEAD_REF master
 )
 

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -13,8 +13,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DCMAKE_CXX_STANDARD=17
-        # Abseil requires C++17 or later, but let the ports decide the C++ standard
-        -DABSL_PROPAGATE_CXX_STD=OFF
+        -DABSL_PROPAGATE_CXX_STD=ON
         -DABSL_ENABLE_INSTALL=ON
         -DABSL_MSVC_STATIC_RUNTIME=${USE_STATIC_RUNTIME}
         -DABSL_BUILD_TESTING=OFF

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -13,7 +13,8 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DCMAKE_CXX_STANDARD=17
-        -DABSL_PROPAGATE_CXX_STD=ON
+        # Abseil requires C++17 or later, but let the ports decide the C++ standard
+        -DABSL_PROPAGATE_CXX_STD=OFF
         -DABSL_ENABLE_INSTALL=ON
         -DABSL_MSVC_STATIC_RUNTIME=${USE_STATIC_RUNTIME}
         -DABSL_BUILD_TESTING=OFF

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "abseil",
-  "version": "20250127.0",
+  "version": "20250127.1",
   "description": "Abseil is an open-source collection of C++ code (compliant to C++17) designed to augment the C++ standard library",
   "homepage": "https://github.com/abseil/abseil-cpp",
   "license": "Apache-2.0",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e82bd6e53e8cb0903bc8563ff651f64b11f7f12c",
+      "git-tree": "3bc05135c18d89678158699cea8e3b9c9976dd26",
       "version": "20250127.1",
       "port-version": 0
     },

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3bc05135c18d89678158699cea8e3b9c9976dd26",
+      "git-tree": "e82bd6e53e8cb0903bc8563ff651f64b11f7f12c",
       "version": "20250127.1",
       "port-version": 0
     },

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3bc05135c18d89678158699cea8e3b9c9976dd26",
+      "version": "20250127.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c7390005ad636f6d71d6269fe2a9fb8feecce07c",
       "version": "20250127.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,7 +1,7 @@
 {
   "default": {
     "abseil": {
-      "baseline": "20250127.0",
+      "baseline": "20250127.1",
       "port-version": 0
     },
     "apple-crypto": {


### PR DESCRIPTION
### Changes

Prepare update to the latest version

### References

- https://github.com/abseil/abseil-cpp/releases/tag/20250127.1
- https://github.com/abseil/abseil-cpp/releases/tag/20250512.0

