### PR TITLE
[minja] Create a new port

### DIFF
--- a/ports/minja/fix-cmake.patch
+++ b/ports/minja/fix-cmake.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fcc3f41..15fce06 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,6 @@
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.22)
++set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_C_STANDARD 11)
+ 
+ # nsync provides portable synchronization primitives, such as mutexes and
+ # condition variables.
+@@ -88,7 +90,7 @@ if ("${CMAKE_C_COMPILER_ID}X" STREQUAL "MSVCX")
+ endif ()
+ 
+ # Pick the include directory for the operating system.
+-if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
++if (("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX") OR ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsStoreX"))
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/win32")
+ 	set (NSYNC_CPP_FLAGS "/TP")
+ 
+@@ -110,7 +112,7 @@ if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
+ 	set (NSYNC_TEST_OS_SRC
+ 		"platform/win32/src/start_thread.c"
+ 	)
+-elseif ("${CMAKE_SYSTEM_NAME}X" STREQUAL "DarwinX")
++elseif (("${CMAKE_SYSTEM_NAME}X" STREQUAL "DarwinX") OR ("${CMAKE_SYSTEM_NAME}X" STREQUAL "iOSX"))
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/macos")
+ 	# Some versions of MacOS, such as Sierra, require _DARWIN_C_SOURCE
+ 	# when including certin C++ standard header files, such as <mutex>.
+@@ -232,7 +234,7 @@ elseif (("${CMAKE_SYSTEM_PROCESSOR}X" STREQUAL "ppc64X"))
+ endif ()
+ 
+ # Windows uses some include files from the posix directory also.
+-if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
++if (("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX") OR ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsStoreX"))
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/posix")
+ endif ()
+ 
+@@ -398,7 +400,7 @@ if (NSYNC_ENABLE_TESTS)
+ 	endforeach (t)
+ endif ()
+ 
+-set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
++set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY FALSE)
+ 
+ install (TARGETS nsync EXPORT nsync
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries

--- a/ports/minja/portfile.cmake
+++ b/ports/minja/portfile.cmake
@@ -1,0 +1,21 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/minja
+    REF f06140fa52fd140fe38e531ec373d8dc9c86aa06
+    SHA512 7ddbfbbdbeff0e05f9c8106173f14a855962e570dd97cdc3224ccc1b6e10035ee3df7bc03ff06229ddd1dfdd611124a842cba19be45a73e9a36a43e8105b76a6
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DMINJA_TEST_ENABLED=OFF
+        -DMINJA_EXAMPLE_ENABLED=OFF
+        -DMINJA_FUZZTEST_ENABLED=OFF
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/minja/vcpkg.json
+++ b/ports/minja/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "minja",
+  "version-date": "2025-05-15",
+  "description": "A minimalistic C++ Jinja templating engine for LLM chat templates",
+  "homepage": "https://github.com/google/minja",
+  "license": "MIT",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -116,6 +116,10 @@
       "baseline": "0.11.22",
       "port-version": 0
     },
+    "minja": {
+      "baseline": "2025-05-15",
+      "port-version": 0
+    },
     "ml-dtypes": {
       "baseline": "0.5.2",
       "port-version": 1

--- a/versions/m-/minja.json
+++ b/versions/m-/minja.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "693de623461b7a8158729a5291dfea27e8e69e90",
+      "version-date": "2025-05-15",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

Create `minja` to support later versions of `llama-cpp`

### References

* https://github.com/google/minja/commit/f06140fa52fd140fe38e531ec373d8dc9c86aa06

### Triplet Support

The port is header-only.
