### PR TITLE
[quickjs] Create a new port

### DIFF
--- a/ports/quickjs/CMakeLists.txt
+++ b/ports/quickjs/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.21)
+project(quickjs LANGUAGES C)
+
+include(GNUInstallDirs)
+
+add_library(quickjs STATIC
+    cutils.c
+    dtoa.c
+    # libregexp.c
+    libunicode.c
+    # qjs.c
+    # qjsc.c
+    quickjs-libc.c
+    quickjs.c
+)
+target_compile_features(quickjs PUBLIC c_std_11)
+
+if(MSVC)
+    target_compile_definitions(quickjs PRIVATE
+        _CRT_SECURE_NO_WARNINGS
+    )
+endif()
+
+install(TARGETS quickjs DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/ports/quickjs/CMakeLists.txt
+++ b/ports/quickjs/CMakeLists.txt
@@ -3,6 +3,8 @@ project(quickjs LANGUAGES C)
 
 include(GNUInstallDirs)
 
+file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" BUILD_VERSION)
+
 add_library(quickjs STATIC
     cutils.c
     dtoa.c
@@ -15,6 +17,9 @@ add_library(quickjs STATIC
 )
 target_compile_features(quickjs PUBLIC c_std_11)
 
+target_compile_definitions(quickjs PRIVATE
+    CONFIG_VERSION="${BUILD_VERSION}"
+)
 if(MSVC)
     target_compile_definitions(quickjs PRIVATE
         _CRT_SECURE_NO_WARNINGS
@@ -22,3 +27,4 @@ if(MSVC)
 endif()
 
 install(TARGETS quickjs DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES "quickjs.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/ports/quickjs/portfile.cmake
+++ b/ports/quickjs/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bellard/quickjs
+    REF 638ec8ca5e1d4aed002a9fb3ef3358e2a6bc42ab
+    SHA512 d3fc9cf4d6f7eb17ca8edca5ef5a4bd9eb66fe8b506c2e36bb12c98ed6a1d3dd7550ad6331e03eaf1ebcc5cfa54e1cac74df45837d2d4a1942b354fdf90abf9d
+    HEAD_REF master
+)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+set(VCPKG_PLATFORM_TOOLSET ClangCL) # CMAKE_GENERATOR_TOOLSET
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/quickjs/vcpkg.json
+++ b/ports/quickjs/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "quickjs",
   "version-date": "2025-05-30",
-  "description": "...",
-  "homepage": "https://github.com/bellard/quickjs",
-  "license": null,
+  "description": "QuickJS is a small and embeddable Javascript engine.",
+  "homepage": "https://bellard.org/quickjs/",
+  "license": "MIT",
   "supports": "!windows",
   "dependencies": [
     {

--- a/ports/quickjs/vcpkg.json
+++ b/ports/quickjs/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "quickjs",
+  "version-date": "2025-05-30",
+  "description": "...",
+  "homepage": "https://github.com/bellard/quickjs",
+  "license": null,
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/test/vcpkg.json
+++ b/test/vcpkg.json
@@ -127,6 +127,10 @@
           "platform": "windows"
         },
         {
+          "name": "quickjs",
+          "platform": "!windows"
+        },
+        {
           "name": "spine-runtimes",
           "features": [
             "sdl2"
@@ -145,14 +149,14 @@
         },
         {
           "name": "tensorflow-lite",
-          "platform": "windows | linux | android | osx | ios"
-        },
-        {
-          "name": "tensorflow-lite",
           "features": [
             "gpu"
           ],
           "platform": "windows & !arm"
+        },
+        {
+          "name": "tensorflow-lite",
+          "platform": "windows | linux | android | osx | ios"
         },
         "xatlas",
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -212,6 +212,10 @@
       "baseline": "2024-06-17",
       "port-version": 0
     },
+    "quickjs": {
+      "baseline": "2025-05-30",
+      "port-version": 0
+    },
     "ruy": {
       "baseline": "2024-03-22",
       "port-version": 0

--- a/versions/q-/quickjs.json
+++ b/versions/q-/quickjs.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8b34578b186d289ea1bfb238384df73f18da6008",
+      "version-date": "2025-05-30",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

...

### References

* https://github.com/bellard/quickjs/commit/638ec8ca5e1d4aed002a9fb3ef3358e2a6bc42ab

### Triplet Support

The project doesn't support Windows platform

* `x64-osx`
* `x64-linux`
