### PR TITLE
[nvtx3,nvidia-tools-extension-sdk] Create a new port with 3.2.0, make VCPKG_POLICY_EMPTY_PACKAGE

### DIFF
--- a/ports/nvidia-tools-extension-sdk/portfile.cmake
+++ b/ports/nvidia-tools-extension-sdk/portfile.cmake
@@ -1,19 +1,2 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO NVIDIA/NVTX
-    REF v${VERSION}
-    SHA512 0ed51db1e77c7eb3f8c6e8a425720c13906860f54cb97dc313def0e4688b2d6f572a071fcbce0fae6f2a1abb151721dab6711287f9d9dd609b4369ae84805152
-    HEAD_REF release-v3
-)
-
-file(INSTALL "${SOURCE_PATH}/c/include/nvtx3" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug"
-    "${CURRENT_PACKAGES_DIR}/lib"
-)
-file(INSTALL "${SOURCE_PATH}/c/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+message(STATUS "The port will install 'nvtx3' instead")

--- a/ports/nvidia-tools-extension-sdk/vcpkg.json
+++ b/ports/nvidia-tools-extension-sdk/vcpkg.json
@@ -1,7 +1,10 @@
 {
   "name": "nvidia-tools-extension-sdk",
-  "version": "3.1.1",
-  "description": "The NVIDIA® Tools Extension SDK (NVTX)",
+  "version": "3.2.0",
+  "description": "Redirection port for 'nvtx3'",
   "homepage": "https://nvidia.github.io/NVTX/",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": [
+    "nvtx3"
+  ]
 }

--- a/ports/nvtx3/portfile.cmake
+++ b/ports/nvtx3/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/NVTX
+    REF v${VERSION}
+    SHA512 b65eb392f2fcf4a96fef84932cf61ceb85ae8a424e1128e77adde1e0452291d5e3eacd8bc0354f8878551ede0070dc0881406a4ffac1f3b13d2f7e56f4e0c41a
+    HEAD_REF release-v3
+)
+
+# header-only library. we don't need other configurations
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/c"
+    OPTIONS
+        -DNVTX3_TARGETS_NOT_USING_IMPORTED=ON
+        -DNVTX3_INSTALL=ON
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/nvtx3")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+file(INSTALL "${SOURCE_PATH}/c/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nvtx3/vcpkg.json
+++ b/ports/nvtx3/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "nvtx3",
+  "version": "3.2.0",
+  "description": "The NVIDIA® Tools Extension SDK (NVTX)",
+  "homepage": "https://nvidia.github.io/NVTX/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -164,6 +164,10 @@
       "baseline": "2025-02-08",
       "port-version": 0
     },
+    "nvtx3": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "onnx": {
       "baseline": "1.16.2",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -149,7 +149,7 @@
       "port-version": 0
     },
     "nvidia-tools-extension-sdk": {
-      "baseline": "3.1.1",
+      "baseline": "3.2.0",
       "port-version": 0
     },
     "nvidia-triton-client": {

--- a/versions/n-/nvidia-tools-extension-sdk.json
+++ b/versions/n-/nvidia-tools-extension-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d2ffc15de84861f9403c1e1585df48bba06d7d0",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5decf2cf110005ad76a8940adc28cb58a5274f30",
       "version": "3.1.1",
       "port-version": 0

--- a/versions/n-/nvtx3.json
+++ b/versions/n-/nvtx3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c37073ced4ee5c34b325fb25c4aeeff9f35c2900",
+      "version": "3.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Changes

- The port `nvidia-tools-extension-sdk` will be redirected to `nvtx3`
- `nvtx3` now supports `find_package`

```log
nvtx3 provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(nvtx3 CONFIG REQUIRED)
  target_link_libraries(main PRIVATE nvtx3::nvtx3-c nvtx3::nvtx3-cpp)

```

### References

* https://github.com/NVIDIA/NVTX/releases/tag/v3.2.0
* #418 
