### PR TITLE
[nvidia-cutlass] use FindCUDNN.cmake from vcpkg port 'cudnn'

### DIFF
--- a/ports/nvidia-cutlass/fix-find-cudnn.patch
+++ b/ports/nvidia-cutlass/fix-find-cudnn.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b54b833..e9cb236 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -810,7 +810,7 @@ if (CUTLASS_ENABLE_CUBLAS)
+   target_compile_definitions(CUTLASS INTERFACE CUTLASS_ENABLE_CUBLAS=1)
+ endif()
+ 
+-include(${CMAKE_CURRENT_SOURCE_DIR}/cuDNN.cmake)
++find_package(CUDNN REQUIRED) # FindCUDNN.cmake from vcpkg 'cudnn' port
+ 
+ if (CUTLASS_ENABLE_CUDNN)
+   target_compile_definitions(CUTLASS INTERFACE CUTLASS_ENABLE_CUDNN=1)

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 b02775b7a364a708388fd7ce1c5526453cfb42f35fd9143aad0b0efd2dc10b66feb1539ad08f0f9089fd241e0bdb2002fdeea2604cfdba7a519aceb4f0df0557
     HEAD_REF main
+    PATCHES
+        fix-find-cudnn.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nvidia-cutlass",
   "version-semver": "3.9.0",
+  "port-version": 1,
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -142,7 +142,7 @@
     },
     "nvidia-cutlass": {
       "baseline": "3.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nvidia-nvbench": {
       "baseline": "2024-06-01",

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75dc9a9bd5a1dc93e3a5763cf94649543a7a6efd",
+      "version-semver": "3.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b4954d573adae01012ab6d90bdaed4c2820cb04d",
       "version-semver": "3.9.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

Using the `cudnn` port provides better CUDNN search

### References

- https://github.com/microsoft/vcpkg/blob/master/ports/cudnn/FindCUDNN.cmake
- #412 
- https://github.com/microsoft/vcpkg/pull/46668
