### PR TITLE
[llama-cpp] Update to 2025-08-27

### DIFF
--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -3,12 +3,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled) # there are some python scripts
 
-# https://github.com/ggml-org/llama.cpp/releases/tag/b6092
+# https://github.com/ggml-org/llama.cpp/releases/tag/b6301
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/llama.cpp
     REF "b${VERSION}"
-    SHA512 3975d176316cc9f3fdfa2183581ca4c57b30f3fc9c15d7eb94144be2de323d5fd2cd82fc345965cc1b8334059657a7666331efdb4fa7adf74114282ecb2abbec
+    SHA512 8f7900829f1b0f99e4b59f8e24def0e975ac6e7186619daaa77477506f93609243188589285f9fc46b924f215a1eed1ae20b386340c507d40c0865de8c1eb3be
     HEAD_REF master
     PATCHES
         fix-3rdparty.patch

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-cpp",
-  "version": "6092",
+  "version": "6301",
   "description": "LLM inference in C/C++",
   "homepage": "https://github.com/ggml-org/llama.cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,7 +105,7 @@
       "port-version": 0
     },
     "llama-cpp": {
-      "baseline": "6092",
+      "baseline": "6301",
       "port-version": 0
     },
     "magma": {

--- a/versions/l-/llama-cpp.json
+++ b/versions/l-/llama-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96202cb904705c6c747b5c954b1d3caddc7a92a1",
+      "version": "6301",
+      "port-version": 0
+    },
+    {
       "git-tree": "f41a71474d645f7ffc2f4af96d0cfa94b39fb381",
       "version": "6092",
       "port-version": 0


### PR DESCRIPTION

### Changes

Use the later release, which passed all CI workflows.

### References

* https://github.com/ggml-org/llama.cpp/releases/tag/b6301